### PR TITLE
Issue 53 invite

### DIFF
--- a/src/config/Global.ts
+++ b/src/config/Global.ts
@@ -3,5 +3,8 @@ export const global: any = {
     supportServerURL: "https://zumito.ga/server",
     embeds: {
         color: '#f982a2',
-    }
+    },
+    websiteURL: "https://zumito.ga/",
+    botInviteURL: "https://zumito.ga/server/invite",
+    botInviteImgURL: "https://raw.githubusercontent.com/fernandomema/Zumito/botinvite/assets/images/invite.png",
 }

--- a/src/config/Global.ts
+++ b/src/config/Global.ts
@@ -1,10 +1,6 @@
 export const global: any = {
     name: 'Zumito Team Bot',
-    supportServerURL: "https://zumito.ga/server",
     embeds: {
         color: '#f982a2',
     },
-    websiteURL: "https://zumito.ga/",
-    botInviteURL: "https://zumito.ga/server/invite",
-    botInviteImgURL: "https://raw.githubusercontent.com/fernandomema/Zumito/botinvite/assets/images/invite.png",
 }

--- a/src/config/Links.ts
+++ b/src/config/Links.ts
@@ -1,0 +1,10 @@
+export const links: any = {
+      images: {
+            banner: "https://github.com/ZumitoTeam/zumito-bot/blob/main/assets/images/banner.png?raw=true"
+      },
+      sites: {
+            support: "https://zumito.ga/server",
+            website: "https://zumito.ga/",
+            invite: "https://zumito.ga/server/invite"
+      }
+}

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,7 +1,9 @@
 import { statusOptions } from "./StatusOptions.js";
 import { global } from "./Global.js";
+import { links } from "./Links.js";
 
 export const config = {
     statusOptions,
     global,
+    links,
 };

--- a/src/modules/info/commands/invite.ts
+++ b/src/modules/info/commands/invite.ts
@@ -2,7 +2,6 @@ import { EmbedBuilder, GuildMember, ActionRowBuilder, ButtonBuilder, ButtonStyle
 import { Command, CommandArgDefinition, CommandParameters,  CommandType  } from "zumito-framework";
 import { SelectMenuParameters } from "zumito-framework/dist/types/SelectMenuParameters";
 import { config } from "../../../config/index.js";
-import { type } from "os";
 
 export class Invite extends Command {
 

--- a/src/modules/info/commands/invite.ts
+++ b/src/modules/info/commands/invite.ts
@@ -1,0 +1,59 @@
+import { EmbedBuilder, GuildMember, ActionRowBuilder, ButtonBuilder, ButtonStyle } from "discord.js";
+import { config } from "../../../config.js";
+import { Command, CommandArgDefinition, CommandParameters,  CommandType  } from "zumito-framework";
+import { SelectMenuParameters } from "zumito-framework/dist/types/SelectMenuParameters";
+import { type } from "os";
+
+export class Invite extends Command {
+
+    categories = ['information'];
+    examples: string[] = ['']; 
+    aliases = ["inv"]; 
+    args: CommandArgDefinition[] = [];
+    botPermissions = ['VIEW_CHANNEL', 'SEND_MESSAGES', 'USE_EXTERNAL_EMOJIS'];
+    type = CommandType.any;
+
+
+    execute({ message, interaction, args, client, framework, guildSettings }: CommandParameters): void {
+
+        const embed = new EmbedBuilder()
+            .setTitle(framework.translations.get('command.invite.author', guildSettings.lang) + ' ' + config.name)
+            .setDescription(framework.translations.get('command.invite.short.description', guildSettings.lang))
+            .setImage(config.botInviteImgURL)
+            .setColor(config.embeds.color)
+
+        const row: any = new ActionRowBuilder()
+        .addComponents(
+            new ButtonBuilder()
+            .setLabel(framework.translations.get('command.invite.button.invite', guildSettings.lang))
+            .setStyle(ButtonStyle.Link)
+            .setURL(config.botInviteURL)
+            .setEmoji('988649262042710026'),
+
+            new ButtonBuilder()
+            .setLabel(framework.translations.get('command.invite.button.support', guildSettings.lang))
+            .setStyle(ButtonStyle.Link)
+            .setURL(config.supportServerURL)
+            .setEmoji('879509411285045279'),
+
+            new ButtonBuilder()
+            .setLabel(framework.translations.get('command.invite.button.website', guildSettings.lang))
+            .setStyle(ButtonStyle.Link)
+            .setURL(config.websiteURL)
+            .setEmoji('879510323676200980')
+        );
+
+        (message || interaction!)?.reply({
+            embeds: [embed],
+            allowedMentions: { 
+                repliedUser: false
+            },
+            components: [row],
+            ephemeral: true
+        });
+    }
+
+    selectMenu({ path, interaction, client, framework }: SelectMenuParameters): void {
+
+    }
+}

--- a/src/modules/info/commands/invite.ts
+++ b/src/modules/info/commands/invite.ts
@@ -1,7 +1,7 @@
 import { EmbedBuilder, GuildMember, ActionRowBuilder, ButtonBuilder, ButtonStyle } from "discord.js";
-import { config } from "../../../config.js";
 import { Command, CommandArgDefinition, CommandParameters,  CommandType  } from "zumito-framework";
 import { SelectMenuParameters } from "zumito-framework/dist/types/SelectMenuParameters";
+import { config } from "../../../config/index.js";
 import { type } from "os";
 
 export class Invite extends Command {
@@ -17,29 +17,29 @@ export class Invite extends Command {
     execute({ message, interaction, args, client, framework, guildSettings }: CommandParameters): void {
 
         const embed = new EmbedBuilder()
-            .setTitle(framework.translations.get('command.invite.author', guildSettings.lang) + ' ' + config.name)
+            .setTitle(framework.translations.get('command.invite.author', guildSettings.lang) + ' ' + config.global.name)
             .setDescription(framework.translations.get('command.invite.short.description', guildSettings.lang))
-            .setImage(config.botInviteImgURL)
-            .setColor(config.embeds.color)
+            .setImage(config.links.images.banner)
+            .setColor(config.global.embeds.color)
 
         const row: any = new ActionRowBuilder()
         .addComponents(
             new ButtonBuilder()
             .setLabel(framework.translations.get('command.invite.button.invite', guildSettings.lang))
             .setStyle(ButtonStyle.Link)
-            .setURL(config.botInviteURL)
+            .setURL(config.links.sites.invite)
             .setEmoji('988649262042710026'),
 
             new ButtonBuilder()
             .setLabel(framework.translations.get('command.invite.button.support', guildSettings.lang))
             .setStyle(ButtonStyle.Link)
-            .setURL(config.supportServerURL)
+            .setURL(config.links.sites.support)
             .setEmoji('879509411285045279'),
 
             new ButtonBuilder()
             .setLabel(framework.translations.get('command.invite.button.website', guildSettings.lang))
             .setStyle(ButtonStyle.Link)
-            .setURL(config.websiteURL)
+            .setURL(config.links.sites.website)
             .setEmoji('879510323676200980')
         );
 

--- a/src/modules/info/translations/command/invite/en.json
+++ b/src/modules/info/translations/command/invite/en.json
@@ -1,0 +1,12 @@
+{
+    "description": "You receive a link so you can invite me to any server you manage.",
+    "author": "Invite to",
+    "short": {
+        "description": "Here is the invitation link for you to invite me to your server."
+    },
+    "button":{
+        "invite": "Invite",
+        "support": "Support",
+        "website": "Website"
+    }
+}

--- a/src/modules/info/translations/command/invite/es.json
+++ b/src/modules/info/translations/command/invite/es.json
@@ -1,0 +1,12 @@
+{
+    "description": "Recibes un link para que puedas invitarme a cualquier servidor que administres.",
+    "author": "Invitar a",
+    "short": {
+        "description": "Aquí está el enlace de invitación para que me invites a tu servidor."
+    },
+    "button":{
+        "invite": "Invitacion",
+        "support": "Soporte",
+        "website": "Sitio web"
+    }
+}

--- a/src/modules/info/translations/command/invite/es.json
+++ b/src/modules/info/translations/command/invite/es.json
@@ -1,6 +1,6 @@
 {
     "description": "Recibes un link para que puedas invitarme a cualquier servidor que administres.",
-    "author": "Invitar a",
+    "author": "Invita a",
     "short": {
         "description": "Aquí está el enlace de invitación para que me invites a tu servidor."
     },


### PR DESCRIPTION
**Problem Description:**
Currently, the Discord bot doesn't have a command that allows users to easily obtain the invite links, support, and website for the bot. This makes it difficult for users interested in the bot to join the community and learn more about it.

**Proposed Solution:**
A new invite command has been added to the Discord bot that will allow users to obtain the invite links, support, and website for the bot more easily. A new invite.ts file has been created in the commands folder that contains the code for the new command. Additionally, the commands.ts file has been updated and the inviteCommand() function has been added to include the new command in the commands object.

**Pros:**

- The new command will provide users with easier access to the invite links, support, and website for the bot.
- It will improve accessibility for new users who want to join the bot's community.

**Cons:**

- No cons or negative impacts were identified.
- Please review the code and let us know if any modifications or changes are needed. Thank you for your time and consideration!