### PR TITLE
Fix README: Codefactor badge and link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 </div>
  
 # Zumito 🧃
-[![CodeFactor](https://www.codefactor.io/repository/github/fernandomema/zumito/badge)](https://www.codefactor.io/repository/github/fernandomema/zumito)
+[![CodeFactor](https://www.codefactor.io/repository/github/ZumitoTeam/zumito-bot/badge)](https://www.codefactor.io/repository/github/ZumitoTeam/zumito-bot)
 ![GitHub Repo stars](https://img.shields.io/github/stars/fernandomema/zumito)
 
 Multipurpose discord bot


### PR DESCRIPTION
The codefactor links are not updated since the repo migration from `fernandomema/zumito` to `ZumitoTeam/zumito-bot`