### PR TITLE
Issue 109 request to fix title duplication in the help command of zumito bot

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "dotenv": "^16.0.3",
         "ffmpeg-static": "^5.1.0",
         "fs-readdir-recursive": "^1.1.0",
-        "zumito-framework": "^1.1.69"
+        "zumito-framework": "^1.1.71"
       },
       "devDependencies": {
         "@jsdevtools/version-bump-prompt": "^6.1.0",
@@ -4613,9 +4613,9 @@
       }
     },
     "node_modules/zumito-framework": {
-      "version": "1.1.69",
-      "resolved": "https://registry.npmjs.org/zumito-framework/-/zumito-framework-1.1.69.tgz",
-      "integrity": "sha512-/62bTJqwyIeu0RRsLVKqYAJMpdqAKSa3k0eI9QeaLtesRso9A3P3vvnCLt6iC1CU93TesAEfpDJrCR+Q76Gmng==",
+      "version": "1.1.71",
+      "resolved": "https://registry.npmjs.org/zumito-framework/-/zumito-framework-1.1.71.tgz",
+      "integrity": "sha512-pB2DPTaeopoaBDAGi9lYRhaz/LLoWEacnTutsYPkZuATnD2PojfHbvrX8vvQeXGZxbV1BIv5GrkYM11YqTJusw==",
       "dependencies": {
         "@discordjs/rest": "^1.7.0",
         "@types/express": "^4.17.13",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "dotenv": "^16.0.3",
     "ffmpeg-static": "^5.1.0",
     "fs-readdir-recursive": "^1.1.0",
-    "zumito-framework": "^1.1.69"
+    "zumito-framework": "^1.1.71"
   },
   "devDependencies": {
     "@jsdevtools/version-bump-prompt": "^6.1.0",

--- a/src/config/Global.ts
+++ b/src/config/Global.ts
@@ -1,5 +1,5 @@
 export const global: any = {
-    name: 'Zumito Team Bot',
+    name: 'Zumito',
     embeds: {
         color: '#f982a2',
     },

--- a/src/modules/global/translations/en.json
+++ b/src/modules/global/translations/en.json
@@ -10,7 +10,7 @@
             "information": {
                 "name": "Information",
                 "description": "Information commands",
-                "emoji": "ℹ️"
+                "emoji": "🏳️"
             },
             "configuration": {
                 "name": "Configuration",

--- a/src/modules/global/translations/es.json
+++ b/src/modules/global/translations/es.json
@@ -9,7 +9,8 @@
         "category": {
             "information": {
                 "name": "Informacion",
-                "description": "Comandos de información"
+                "description": "Comandos de información",
+                "emoji": "🏳️"
             },
             "configuration": {
                 "name": "Configuración",

--- a/src/modules/info/commands/help.ts
+++ b/src/modules/info/commands/help.ts
@@ -290,10 +290,16 @@ export class Help extends Command {
         let selectMenuOptions: any = [];
         for (let category of categories) {
             let selectMenuOption: any = {
-                label: framework.translations.get(
-                    `global.category.${category}.name`,
-                    guildSettings.lang
-                ),
+                label:
+                    framework.translations.get(
+                        `global.category.${category}.emoji`,
+                        guildSettings.lang
+                    ) +
+                    " " +
+                    framework.translations.get(
+                        `global.category.${category}.name`,
+                        guildSettings.lang
+                    ),
                 value: category,
                 description: framework.translations.get(
                     `global.category.${category}.description`,

--- a/src/modules/info/commands/help.ts
+++ b/src/modules/info/commands/help.ts
@@ -80,7 +80,7 @@ export class Help extends Command {
                 
 				.addFields([{
                     name: category, 
-                    value: framework.translations.get('command.help.field.detailed', guildSettings.lang) + ': ' + '' + '`' + this.getPrefix(guildSettings) + 'help [command]' + '`' + '\n' + framework.translations.get('command.help.field.support', guildSettings.lang) + ' [' + framework.translations.get('command.help.field.support_server', guildSettings.lang) + '](' + config.global.supportServerURL + ')',
+                    value: framework.translations.get('command.help.field.detailed', guildSettings.lang) + ': ' + '' + '`' + this.getPrefix(guildSettings) + 'help [command]' + '`' + '\n' + framework.translations.get('command.help.field.support', guildSettings.lang) + ' [' + framework.translations.get('command.help.field.support_server', guildSettings.lang) + '](' + config.links.sites.support + ')',
                 }]);
 			let commands: Command[] = Array.from(framework.commands.values()).filter((c: Command) => c.categories.includes(category));
 			for(let i = 0; i < commands.length; i++) {
@@ -192,7 +192,7 @@ export class Help extends Command {
         .setAuthor({ 
             name: framework.translations.get('command.help.author.command', guildSettings.lang) + ' ' + `${command.name}`, 
             iconURL: framework.client.user!.displayAvatarURL(), 
-            url: 'https://zumito.ga/commands/' + `${command.name}` 
+            url: 'https://bot.zumito.dev/commands/' + `${command.name}` 
         })
         .setDescription(framework.translations.get(`command.${command.name}.description`, guildSettings.lang))
         .addFields([{

--- a/src/modules/info/commands/help.ts
+++ b/src/modules/info/commands/help.ts
@@ -161,39 +161,81 @@ export class Help extends Command {
                                 guildSettings.lang
                             ) +
                             "](" +
-                            config.links.sites.support +
+                            config.global.supportServerURL +
                             ")",
                     },
                 ]);
             let commands: Command[] = Array.from(
                 framework.commands.values()
             ).filter((c: Command) => c.categories.includes(category));
+            let valuesToPush: string[] = [];
             for (let i = 0; i < commands.length; i++) {
-                if (i % 4 == 0) {
-                    categoryEmbed
-                        .addFields([
-                            {
-                                name:
-                                    "📖" +
-                                    " " +
-                                    framework.translations.get(
-                                        "command.help.commands",
-                                        guildSettings.lang
-                                    ),
-                                value:
-                                    "```" +
-                                    (commands[i]?.name || "") +
-                                    "       " +
-                                    (commands[i + 1]?.name || "") +
-                                    "       " +
-                                    (commands[i + 2]?.name || "") +
-                                    "       " +
-                                    (commands[i + 3]?.name || "") +
-                                    "```",
-                            },
-                        ])
+                if (interaction.values[0] === "information" && i % 4 == 0) {
+                    i == 4 &&
+                        categoryEmbed
+                            .addFields([
+                                {
+                                    name:
+                                        "📖" +
+                                        " " +
+                                        framework.translations.get(
+                                            "command.help.commands",
+                                            guildSettings.lang
+                                        ),
+                                    value:
+                                        "```" +
+                                        (commands[i]?.name || "") +
+                                        "       " +
+                                        (commands[i + 1]?.name || "") +
+                                        "       " +
+                                        (commands[i + 2]?.name || "") +
+                                        "       " +
+                                        (commands[i + 3]?.name || "") +
+                                        "       " +
+                                        valuesToPush.join("") +
+                                        "```",
+                                },
+                            ])
 
-                        .setColor(config.global.embeds.color);
+                            .setColor(config.global.embeds.color);
+                    i == 0 &&
+                        valuesToPush.push(
+                            (commands[i]?.name || "") +
+                                "       " +
+                                (commands[i + 1]?.name || "") +
+                                "       " +
+                                (commands[i + 2]?.name || "") +
+                                "       " +
+                                (commands[i + 3]?.name || "")
+                        );
+                } else {
+                    if (i % 4 == 0) {
+                        categoryEmbed
+                            .addFields([
+                                {
+                                    name:
+                                        "📖" +
+                                        " " +
+                                        framework.translations.get(
+                                            "command.help.commands",
+                                            guildSettings.lang
+                                        ),
+                                    value:
+                                        "```" +
+                                        (commands[i]?.name || "") +
+                                        "       " +
+                                        (commands[i + 1]?.name || "") +
+                                        "       " +
+                                        (commands[i + 2]?.name || "") +
+                                        "       " +
+                                        (commands[i + 3]?.name || "") +
+                                        "       " +
+                                        "```",
+                                },
+                            ])
+
+                            .setColor(config.global.embeds.color);
+                    }
                 }
             }
             const row1: any = new ActionRowBuilder().addComponents(
@@ -369,7 +411,7 @@ export class Help extends Command {
                     " " +
                     `${command.name}`,
                 iconURL: framework.client.user!.displayAvatarURL(),
-                url: "https://bot.zumito.dev/commands/" + `${command.name}`,
+                url: "https://zumito.ga/commands/" + `${command.name}`,
             })
             .setDescription(
                 framework.translations.get(

--- a/src/modules/info/commands/help.ts
+++ b/src/modules/info/commands/help.ts
@@ -201,11 +201,11 @@ export class Help extends Command {
                     i == 0 &&
                         valuesToPush.push(
                             (commands[i]?.name || "") +
-                                "       " +
+                                "     " +
                                 (commands[i + 1]?.name || "") +
-                                "       " +
+                                "         " +
                                 (commands[i + 2]?.name || "") +
-                                "       " +
+                                "             " +
                                 (commands[i + 3]?.name || "")
                         );
                 } else {

--- a/src/modules/info/commands/help.ts
+++ b/src/modules/info/commands/help.ts
@@ -1,123 +1,240 @@
-import { ActionRow, ActionRowBuilder, AnyComponentBuilder, CommandInteraction, EmbedBuilder, ImageURLOptions, StringSelectMenuBuilder, StringSelectMenuInteraction } from "discord.js";
-import { Command, CommandParameters, ZumitoFramework, CommandType } from "zumito-framework";
+import {
+    ActionRow,
+    ActionRowBuilder,
+    AnyComponentBuilder,
+    CommandInteraction,
+    EmbedBuilder,
+    ImageURLOptions,
+    StringSelectMenuBuilder,
+    StringSelectMenuInteraction,
+} from "discord.js";
+import {
+    Command,
+    CommandParameters,
+    ZumitoFramework,
+    CommandType,
+} from "zumito-framework";
 import { SelectMenuParameters } from "zumito-framework/dist/types/SelectMenuParameters";
 import { config } from "../../../config/index.js";
 import { type } from "os";
 
 export class Help extends Command {
-
-    categories = ['information'];
-    examples: string[] = ["", "ping"]; 
-    aliases = ["?", "h"]; 
-    args: any = [{
-        name: "command",
-        type: "string",
-        optional: true
-    }];
-    botPermissions = ['VIEW_CHANNEL', 'SEND_MESSAGES', 'EMBED_LINKS', 'USE_EXTERNAL_EMOJIS'];
+    categories = ["information"];
+    examples: string[] = ["", "ping"];
+    aliases = ["?", "h"];
+    args: any = [
+        {
+            name: "command",
+            type: "string",
+            optional: true,
+        },
+    ];
+    botPermissions = [
+        "VIEW_CHANNEL",
+        "SEND_MESSAGES",
+        "EMBED_LINKS",
+        "USE_EXTERNAL_EMOJIS",
+    ];
     type = CommandType.any;
 
-    execute({ message, interaction, args, client, framework, guildSettings }: CommandParameters): void {
-        if (args.has('command')) {
-
-            
-            if (framework.commands.has(args.get('command'))) {
-                let command: Command = framework.commands.get(args.get('command'))!;
-                const row1: any = new ActionRowBuilder().addComponents(this.getCategoriesSelectMenu(framework, guildSettings));
-                const commandEmbed = this.getCommandEmbed(framework, command, guildSettings);
-                (message || interaction as unknown as CommandInteraction).reply({ 
-                    embeds: [commandEmbed], 
+    execute({
+        message,
+        interaction,
+        args,
+        client,
+        framework,
+        guildSettings,
+    }: CommandParameters): void {
+        if (args.has("command")) {
+            if (framework.commands.has(args.get("command"))) {
+                let command: Command = framework.commands.get(
+                    args.get("command")
+                )!;
+                const row1: any = new ActionRowBuilder().addComponents(
+                    this.getCategoriesSelectMenu(framework, guildSettings)
+                );
+                const commandEmbed = this.getCommandEmbed(
+                    framework,
+                    command,
+                    guildSettings
+                );
+                (
+                    message || (interaction as unknown as CommandInteraction)
+                ).reply({
+                    embeds: [commandEmbed],
                     components: [row1],
-                    allowedMentions: { 
-                        repliedUser: false 
-                    }
+                    allowedMentions: {
+                        repliedUser: false,
+                    },
                 });
             }
         } else {
-            
-            const row: any = new ActionRowBuilder().addComponents(this.getCategoriesSelectMenu(framework, guildSettings));
+            const row: any = new ActionRowBuilder().addComponents(
+                this.getCategoriesSelectMenu(framework, guildSettings)
+            );
 
-            let text0 = framework.translations.get('command.help.greeting.0', guildSettings.lang, { 
-                name: config.global.name
-            });
-            let text1 = framework.translations.get('command.help.greeting.1', guildSettings.lang);
-            let text2 = framework.translations.get('command.help.greeting.2', guildSettings.lang);
+            let text0 = framework.translations.get(
+                "command.help.greeting.0",
+                guildSettings.lang,
+                {
+                    name: config.global.name,
+                }
+            );
+            let text1 = framework.translations.get(
+                "command.help.greeting.1",
+                guildSettings.lang
+            );
+            let text2 = framework.translations.get(
+                "command.help.greeting.2",
+                guildSettings.lang
+            );
 
             const embed = new EmbedBuilder()
-				.setTitle(framework.translations.get('command.help.title', guildSettings.lang))
-				.setDescription(
-                    text0 + "\n\n" + 
-                    text1 + "\n" + 
-                    text2 + "\n"
+                .setTitle(
+                    framework.translations.get(
+                        "command.help.title",
+                        guildSettings.lang
+                    )
                 )
+                .setDescription(text0 + "\n\n" + text1 + "\n" + text2 + "\n")
                 .setColor(config.global.embeds.color);
-                
 
             if (client && client.user) {
-                embed.setThumbnail(client.user.displayAvatarURL({ forceStatic: false }))
+                embed.setThumbnail(
+                    client.user.displayAvatarURL({ forceStatic: false })
+                );
             }
 
-			(message || interaction as unknown as CommandInteraction).reply({ 
-				embeds: [embed], 
-				components: [row],
-				allowedMentions: { 
-					repliedUser: false 
-				}
-			});
+            (message || (interaction as unknown as CommandInteraction)).reply({
+                embeds: [embed],
+                components: [row],
+                allowedMentions: {
+                    repliedUser: false,
+                },
+            });
         }
     }
 
-    async selectMenu({ path, interaction, client, framework, guildSettings }: SelectMenuParameters): Promise<void> {
-		if (path[1] == "category") {
+    async selectMenu({
+        path,
+        interaction,
+        client,
+        framework,
+        guildSettings,
+    }: SelectMenuParameters): Promise<void> {
+        if (path[1] == "category") {
             let category: string = interaction.values[0];
-			let categoryEmbed = new EmbedBuilder()
-				.setAuthor({ 
-                    name: framework.translations.get('command.help.commands_of', guildSettings.lang, { 
-                        name: config.global.name
-                    }), 
-                    iconURL: client!.user!.displayAvatarURL() 
+            let categoryEmbed = new EmbedBuilder()
+                .setAuthor({
+                    name: framework.translations.get(
+                        "command.help.commands_of",
+                        guildSettings.lang,
+                        {
+                            name: config.global.name,
+                        }
+                    ),
+                    iconURL: client!.user!.displayAvatarURL(),
                 })
-                
-				.addFields([{
-                    name: category, 
-                    value: framework.translations.get('command.help.field.detailed', guildSettings.lang) + ': ' + '' + '`' + this.getPrefix(guildSettings) + 'help [command]' + '`' + '\n' + framework.translations.get('command.help.field.support', guildSettings.lang) + ' [' + framework.translations.get('command.help.field.support_server', guildSettings.lang) + '](' + config.links.sites.support + ')',
-                }]);
-			let commands: Command[] = Array.from(framework.commands.values()).filter((c: Command) => c.categories.includes(category));
-			for(let i = 0; i < commands.length; i++) {
-				if(i % 4 == 0) {
-					categoryEmbed.addFields([{
-                        name: '📖' + ' ' + framework.translations.get('command.help.commands', guildSettings.lang), 
-                        value: '```'+(commands[i]?.name || '')+'       '+(commands[i+1]?.name || '')+'       '+(commands[i+2]?.name || '')+'       '+(commands[i+3]?.name || '')+'```'
-                    }])
 
-                .setColor(config.global.embeds.color);
-				}
-			};
-            const row1: any = new ActionRowBuilder().addComponents(this.getCategoriesSelectMenu(framework, guildSettings, category));
-			await interaction.deferUpdate();
-			await interaction.editReply({ 
-				embeds: [categoryEmbed],
-                components: [row1],
-				allowedMentions: { 
-					repliedUser: false 
-				}
-			});
-		} else if(path[1] == "command") {
-            let command: Command | undefined = framework.commands.get(interaction.values[0]);
-			const commandEmbed = this.getCommandEmbed(framework, command!, guildSettings);
-            const row: any = new ActionRowBuilder().addComponents(this.getCategoriesSelectMenu(framework, guildSettings));
+                .addFields([
+                    {
+                        name: category,
+                        value:
+                            framework.translations.get(
+                                "command.help.field.detailed",
+                                guildSettings.lang
+                            ) +
+                            ": " +
+                            "" +
+                            "`" +
+                            this.getPrefix(guildSettings) +
+                            "help [command]" +
+                            "`" +
+                            "\n" +
+                            framework.translations.get(
+                                "command.help.field.support",
+                                guildSettings.lang
+                            ) +
+                            " [" +
+                            framework.translations.get(
+                                "command.help.field.support_server",
+                                guildSettings.lang
+                            ) +
+                            "](" +
+                            config.links.sites.support +
+                            ")",
+                    },
+                ]);
+            let commands: Command[] = Array.from(
+                framework.commands.values()
+            ).filter((c: Command) => c.categories.includes(category));
+            for (let i = 0; i < commands.length; i++) {
+                if (i % 4 == 0) {
+                    categoryEmbed
+                        .addFields([
+                            {
+                                name:
+                                    "📖" +
+                                    " " +
+                                    framework.translations.get(
+                                        "command.help.commands",
+                                        guildSettings.lang
+                                    ),
+                                value:
+                                    "```" +
+                                    (commands[i]?.name || "") +
+                                    "       " +
+                                    (commands[i + 1]?.name || "") +
+                                    "       " +
+                                    (commands[i + 2]?.name || "") +
+                                    "       " +
+                                    (commands[i + 3]?.name || "") +
+                                    "```",
+                            },
+                        ])
+
+                        .setColor(config.global.embeds.color);
+                }
+            }
+            const row1: any = new ActionRowBuilder().addComponents(
+                this.getCategoriesSelectMenu(framework, guildSettings, category)
+            );
             await interaction.deferUpdate();
-			await interaction.editReply({ 
-				embeds: [commandEmbed],
+            await interaction.editReply({
+                embeds: [categoryEmbed],
+                components: [row1],
+                allowedMentions: {
+                    repliedUser: false,
+                },
+            });
+        } else if (path[1] == "command") {
+            let command: Command | undefined = framework.commands.get(
+                interaction.values[0]
+            );
+            const commandEmbed = this.getCommandEmbed(
+                framework,
+                command!,
+                guildSettings
+            );
+            const row: any = new ActionRowBuilder().addComponents(
+                this.getCategoriesSelectMenu(framework, guildSettings)
+            );
+            await interaction.deferUpdate();
+            await interaction.editReply({
+                embeds: [commandEmbed],
                 components: [row],
-				allowedMentions: { 
-					repliedUser: false 
-				}
-			});
-		}
-	}
+                allowedMentions: {
+                    repliedUser: false,
+                },
+            });
+        }
+    }
 
-    getCategoriesSelectMenu(framework: ZumitoFramework, guildSettings: any, selectedCategory?: string): AnyComponentBuilder {
+    getCategoriesSelectMenu(
+        framework: ZumitoFramework,
+        guildSettings: any,
+        selectedCategory?: string
+    ): AnyComponentBuilder {
         let categories: string[] = [];
         framework.commands.forEach((command: Command) => {
             for (let category of command.categories) {
@@ -131,12 +248,23 @@ export class Help extends Command {
         let selectMenuOptions: any = [];
         for (let category of categories) {
             let selectMenuOption: any = {
-                label: framework.translations.get(`global.category.${category}.name`, guildSettings.lang),
+                label: framework.translations.get(
+                    `global.category.${category}.name`,
+                    guildSettings.lang
+                ),
                 value: category,
-                description: framework.translations.get(`global.category.${category}.description`, guildSettings.lang),
-            }
-            if (framework.translations.has(`command.category.${category}.emoji`)) {
-                selectMenuOption.emoji = framework.translations.get(`global.category.${category}.emoji`, guildSettings.lang);
+                description: framework.translations.get(
+                    `global.category.${category}.description`,
+                    guildSettings.lang
+                ),
+            };
+            if (
+                framework.translations.has(`command.category.${category}.emoji`)
+            ) {
+                selectMenuOption.emoji = framework.translations.get(
+                    `global.category.${category}.emoji`,
+                    guildSettings.lang
+                );
             }
             if (selectedCategory == category) {
                 selectMenuOption.default = true;
@@ -144,80 +272,198 @@ export class Help extends Command {
             selectMenuOptions.push(selectMenuOption);
         }
         return new StringSelectMenuBuilder()
-            .setCustomId('help.category')
-            .setPlaceholder(framework.translations.get('command.help.category', guildSettings.lang))
+            .setCustomId("help.category")
+            .setPlaceholder(
+                framework.translations.get(
+                    "command.help.category",
+                    guildSettings.lang
+                )
+            )
             .addOptions(selectMenuOptions);
     }
 
-    getCommandsSelectMenu(framework: ZumitoFramework, category: string, guildSettings: any): AnyComponentBuilder {
-        let commands = Array.from(framework.commands.values()).filter((c: Command) => c.categories.includes(category));
+    getCommandsSelectMenu(
+        framework: ZumitoFramework,
+        category: string,
+        guildSettings: any
+    ): AnyComponentBuilder {
+        let commands = Array.from(framework.commands.values()).filter(
+            (c: Command) => c.categories.includes(category)
+        );
         let selectMenuOptions: any = [];
         for (let command of commands) {
             let selectMenuOption: any = {
                 label: command.name,
                 value: command.name,
-                description: framework.translations.get(`command.${command.name}.description`, guildSettings.lang),
-            }
-            if (framework.translations.has(`command.category.${category}.emoji`)) {
-                selectMenuOption.emoji = framework.translations.get(`command.category.${category}.emoji`, guildSettings.lang);
+                description: framework.translations.get(
+                    `command.${command.name}.description`,
+                    guildSettings.lang
+                ),
+            };
+            if (
+                framework.translations.has(`command.category.${category}.emoji`)
+            ) {
+                selectMenuOption.emoji = framework.translations.get(
+                    `command.category.${category}.emoji`,
+                    guildSettings.lang
+                );
             }
             selectMenuOptions.push(selectMenuOption);
         }
         return new StringSelectMenuBuilder()
-            .setCustomId('help.command')
-            .setPlaceholder(framework.translations.get('command.help.select.command', guildSettings.lang))
+            .setCustomId("help.command")
+            .setPlaceholder(
+                framework.translations.get(
+                    "command.help.select.command",
+                    guildSettings.lang
+                )
+            )
             .addOptions(selectMenuOptions);
     }
 
-    getCommandEmbed(framework: ZumitoFramework, command: Command, guildSettings: any): EmbedBuilder {
+    getCommandEmbed(
+        framework: ZumitoFramework,
+        command: Command,
+        guildSettings: any
+    ): EmbedBuilder {
         let prefix = this.getPrefix(guildSettings);
-        let ussage: string = prefix + command.name + ' ';
+        let ussage: string = prefix + command.name + " ";
         if (command.args && command.args.length > 0) {
             for (let arg of command.args) {
                 if (arg.optional) {
-                    ussage += '<' + framework.translations.get(`command.${command.name}.arguments.${arg.name}.name`, guildSettings.lang) + '>';
+                    ussage +=
+                        "<" +
+                        framework.translations.get(
+                            `command.${command.name}.arguments.${arg.name}.name`,
+                            guildSettings.lang
+                        ) +
+                        ">";
                 } else {
-                    ussage += '[' + framework.translations.get(`command.${command.name}.arguments.${arg.name}.name`, guildSettings.lang) + ']';
+                    ussage +=
+                        "[" +
+                        framework.translations.get(
+                            `command.${command.name}.arguments.${arg.name}.name`,
+                            guildSettings.lang
+                        ) +
+                        "]";
                 }
             }
         }
         let examples: string[] = [];
         if (command.examples && command.examples.length > 0) {
             for (let example of command.examples) {
-                let commandText = command.aliases[Math.floor(Math.random() * (command.aliases.length) + 1)] || command.name;
-                examples.push(prefix + commandText + ' ' + example);
+                let commandText =
+                    command.aliases[
+                        Math.floor(Math.random() * command.aliases.length + 1)
+                    ] || command.name;
+                examples.push(prefix + commandText + " " + example);
             }
         }
         return new EmbedBuilder()
-        .setAuthor({ 
-            name: framework.translations.get('command.help.author.command', guildSettings.lang) + ' ' + `${command.name}`, 
-            iconURL: framework.client.user!.displayAvatarURL(), 
-            url: 'https://bot.zumito.dev/commands/' + `${command.name}` 
-        })
-        .setDescription(framework.translations.get(`command.${command.name}.description`, guildSettings.lang))
-        .addFields([{
-            name: framework.translations.get('command.help.usage', guildSettings.lang), 
-            value: '`' + (ussage || framework.translations.get('global.none', guildSettings.lang)) + '`',
-        }, {
-            name: framework.translations.get('command.help.examples', guildSettings.lang),
-            value: examples.join('\n') || framework.translations.get('command.help.noExamples', guildSettings.lang),
-        }, {
-            name: framework.translations.get('command.help.aliases', guildSettings.lang), 
-            value: command.aliases.join(', ') || framework.translations.get('global.none', guildSettings.lang),
-
-        }, {
-            name: framework.translations.get('command.help.permissions.bot', guildSettings.lang),
-            value: (command?.botPermissions || []).map(p => framework.translations.get(`global.permissions.${p}`)).join('\n') || framework.translations.get('global.none', guildSettings.lang),
-            inline: true
-        }, {
-            name: framework.translations.get('command.help.permissions.user', guildSettings.lang),
-            value: (command?.userPermissions || []).map(p => framework.translations.get(`global.permissions.${p}`)).join('\n') || framework.translations.get('global.none', guildSettings.lang),
-            inline: true
-        }])
-        .setColor(config.global.embeds.color)
+            .setAuthor({
+                name:
+                    framework.translations.get(
+                        "command.help.author.command",
+                        guildSettings.lang
+                    ) +
+                    " " +
+                    `${command.name}`,
+                iconURL: framework.client.user!.displayAvatarURL(),
+                url: "https://bot.zumito.dev/commands/" + `${command.name}`,
+            })
+            .setDescription(
+                framework.translations.get(
+                    `command.${command.name}.description`,
+                    guildSettings.lang
+                )
+            )
+            .addFields([
+                {
+                    name: framework.translations.get(
+                        "command.help.usage",
+                        guildSettings.lang
+                    ),
+                    value:
+                        "`" +
+                        (ussage ||
+                            framework.translations.get(
+                                "global.none",
+                                guildSettings.lang
+                            )) +
+                        "`",
+                },
+                {
+                    name: framework.translations.get(
+                        "command.help.examples",
+                        guildSettings.lang
+                    ),
+                    value:
+                        examples.join("\n") ||
+                        framework.translations.get(
+                            "command.help.noExamples",
+                            guildSettings.lang
+                        ),
+                },
+                {
+                    name: framework.translations.get(
+                        "command.help.aliases",
+                        guildSettings.lang
+                    ),
+                    value:
+                        command.aliases.join(", ") ||
+                        framework.translations.get(
+                            "global.none",
+                            guildSettings.lang
+                        ),
+                },
+                {
+                    name: framework.translations.get(
+                        "command.help.permissions.bot",
+                        guildSettings.lang
+                    ),
+                    value:
+                        (command?.botPermissions || [])
+                            .map((p) =>
+                                framework.translations.get(
+                                    `global.permissions.${p}`
+                                )
+                            )
+                            .join("\n") ||
+                        framework.translations.get(
+                            "global.none",
+                            guildSettings.lang
+                        ),
+                    inline: true,
+                },
+                {
+                    name: framework.translations.get(
+                        "command.help.permissions.user",
+                        guildSettings.lang
+                    ),
+                    value:
+                        (command?.userPermissions || [])
+                            .map((p) =>
+                                framework.translations.get(
+                                    `global.permissions.${p}`
+                                )
+                            )
+                            .join("\n") ||
+                        framework.translations.get(
+                            "global.none",
+                            guildSettings.lang
+                        ),
+                    inline: true,
+                },
+            ])
+            .setColor(config.global.embeds.color);
     }
 
     getPrefix(guildSettings: any, framework?: ZumitoFramework): string {
-        return guildSettings?.prefix || process.env.BOTPREFIX || framework?.settings.defaultPrefix || '!';
+        return (
+            guildSettings?.prefix ||
+            process.env.BOTPREFIX ||
+            framework?.settings.defaultPrefix ||
+            "!"
+        );
     }
 }


### PR DESCRIPTION
# I have solved that issue in 2 parts:

## Title duplication bug

-   For start, we have to get some context in [help command file](https://github.com/ZumitoTeam/zumito-bot/blob/issue-109-Request_to_Fix_Title_Duplication_in_the_Help_Command_of_Zumito_Bot/src/modules/info/commands/help.ts):

    -   There was a `for` iteration in lines 86 to 91:

    ````typescript
    for (let i = 0; i < commands.length; i++) {
        if (i % 4 == 0) {
            categoryEmbed
                .addFields([
                    {
                        name:
                            "📖" +
                            " " +
                            framework.translations.get(
                                "command.help.commands",
                                guildSettings.lang
                            ),
                        value:
                            "`" +
                            (commands[i]?.name || "") +
                            " " +
                            (commands[i + 1]?.name || "") +
                            " " +
                            (commands[i + 2]?.name || "") +
                            " " +
                            (commands[i + 3]?.name || "") +
                            "```",
                    },
                ])

                .setColor(config.global.embeds.color);
        }
    }
    ````

    -   That bucle when the help argument is **configuration**, only runs 1 time (i==0) and because `0 % 4 == 0` it executes `categoryEmbed.addField` once.

    -   But in the other hand, when help argument is **information** it runs 8 times (i == 0,1,2,3,4,5,6,7) but only executes `categoryEmbed.addField` 2 times (i==0,4) because `0 % 4 == 0` and `4 % 4 == 0`. So, that 2 times it executes:

    ````typescript
    categoryEmbed.addFields([
        {
            name:
                "📖" +
                " " +
                framework.translations.get(
                    "command.help.commands",
                    guildSettings.lang
                ),
            value:
                "`" +
                (commands[i]?.name || "") +
                " " +
                (commands[i + 1]?.name || "") +
                " " +
                (commands[i + 2]?.name || "") +
                " " +
                (commands[i + 3]?.name || "") +
                "```",
        },
    ]);
    ````

    But we do not want to have two names and two values, we have to have only one name, and 2 values, when `i==0 && i==4`
    So, when `i==0` and help argument is **configuration** we have to execute ` categoryEmbed.addField [...]` but when is **information** we have to save the following string:

    ````typescript
    "`" +
        (commands[i]?.name || "") +
        " " +
        (commands[i + 1]?.name || "") +
        " " +
        (commands[i + 2]?.name || "") +
        " " +
        (commands[i + 3]?.name || "") +
        "```";
    ````

    So I have created a new array before the bucle:

    ```typescript
    let valuesToPush: string[] = [];
    ```

    And in the bucle we check if `interaction.values[0] === "information"` or `interaction.values[0] === "configuration"`.
    The bucle will be like that:

    ````typescript
    for (let i = 0; i < commands.length; i++) {
        if (interaction.values[0] === "information" && i % 4 == 0) {
            i == 4 && // when i==4 we have to push the values of the previous iteration
                categoryEmbed
                    .addFields([
                        {
                            name:
                                "📖" +
                                " " +
                                framework.translations.get(
                                    "command.help.commands",
                                    guildSettings.lang
                                ),
                            value:
                                "```" +
                                (commands[i]?.name || "") +
                                "       " +
                                (commands[i + 1]?.name || "") +
                                "       " +
                                (commands[i + 2]?.name || "") +
                                "       " +
                                (commands[i + 3]?.name || "") +
                                "       " +
                                valuesToPush.join("") + // Values of the previous iteration
                                "```",
                        },
                    ])

                    .setColor(config.global.embeds.color);
            i == 0 && // Only save the value, do not push it to .addFields()
                valuesToPush.push(
                    (commands[i]?.name || "") +
                        "       " +
                        (commands[i + 1]?.name || "") +
                        "       " +
                        (commands[i + 2]?.name || "") +
                        "       " +
                        (commands[i + 3]?.name || "")
                );
        } else {
            // If interaction.values[0] === "configuration" do it normally
            if (i % 4 == 0) {
                categoryEmbed
                    .addFields([
                        {
                            name:
                                "📖" +
                                " " +
                                framework.translations.get(
                                    "command.help.commands",
                                    guildSettings.lang
                                ),
                            value:
                                "```" +
                                (commands[i]?.name || "") +
                                "       " +
                                (commands[i + 1]?.name || "") +
                                "       " +
                                (commands[i + 2]?.name || "") +
                                "       " +
                                (commands[i + 3]?.name || "") +
                                "       " +
                                "```",
                        },
                    ])
                    .setColor(config.global.embeds.color);
            } // End if i%4==0
        } // End else's if interaction.values[0] === "information" && i % 4 == 0
    } // End for
    ````

    <br><br>

    ***

    ## Emojis in help command

    -   The emojis in the help command were not added. It was so easy, I only had to add the following code in the label of the menu:

    ```typescript
    framework.translations.get(
        `global.category.${category}.emoji`,
        guildSettings.lang
    ) + " "; // Space to separate the emoji from the text
    ```

    But when the languaje was changed to spanish it didn't show the information's emoji, so I had to add the emoji in the translation file.

---

-   For extra, I've formatted the code with Prettier and I changed information emoji: `ℹ️ => 🏳️`