### PR TITLE
Issue 145  refactor and translate the help command

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,7 @@
         "type": "node",
         "request": "launch",
         "runtimeExecutable": "node",
-        "runtimeArgs": ["--loader", "ts-node/esm", "--preserve-symlinks"],
+        "runtimeArgs": ["--import", "tsx", "--preserve-symlinks"],
   
         "args": ["src/Bot.ts"],
         

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,45 @@
+import typescriptEslint from "@typescript-eslint/eslint-plugin";
+import tsParser from "@typescript-eslint/parser";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import js from "@eslint/js";
+import { FlatCompat } from "@eslint/eslintrc";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const compat = new FlatCompat({
+    baseDirectory: __dirname,
+    recommendedConfig: js.configs.recommended,
+    allConfig: js.configs.all
+});
+
+export default [
+    ...compat.extends("eslint:recommended", "plugin:@typescript-eslint/recommended"),
+    {
+        plugins: {
+            "@typescript-eslint": typescriptEslint,
+        },
+
+        "env": {
+            "node": true,
+        },
+
+        languageOptions: {
+            parser: tsParser,
+        },
+
+        rules: {
+            "no-unused-vars": "error",
+            "no-undef": "error",
+            "indent": ["error", 4],
+
+            "no-multiple-empty-lines": ["error", {
+                max: 1,
+            }],
+            "@typescript-eslint/no-unused-vars": "error",
+            "@typescript-eslint/no-explicit-any": "warn",
+            "@typescript-eslint/no-unused-expressions": "error",
+            "prefer-const": "error",
+        },
+    },
+];

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,19 +12,25 @@
         "@discordjs/opus": "^0.9.0",
         "@discordjs/rest": "^1.7.0",
         "@discordjs/voice": "^0.16.0",
+        "@typescript-eslint/eslint-plugin": "^8.1.0",
+        "@typescript-eslint/parser": "^8.1.0",
         "discord.js": "^14.14.1",
         "dotenv": "^16.0.3",
         "ffmpeg-static": "^5.1.0",
         "fs-readdir-recursive": "^1.1.0",
-        "zumito-framework": "^1.1.72-dev-10395111434.0"
+        "zumito-framework": "^1.1.72-dev-10433285214.0"
       },
       "devDependencies": {
+        "@eslint/js": "^9.9.0",
         "@jsdevtools/version-bump-prompt": "^6.1.0",
         "@types/express": "^4.17.17",
         "@types/node": "^18.15.11",
+        "eslint": "^9.9.0",
+        "globals": "^15.9.0",
         "ts-node": "^10.9.1",
         "tsx": "^4.7.2",
-        "typescript": "^5.0.4"
+        "typescript": "^5.0.4",
+        "typescript-eslint": "^8.1.0"
       },
       "engines": {
         "node": ">=18.0.0",
@@ -1287,12 +1293,131 @@
         "node": ">=12"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
+      "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.11.0.tgz",
+      "integrity": "sha512-G/M/tIiMrTAxEWRfLfQJMmGNX28IxBg4PBz8XqQhqUHLFI6TL2htpIB1iQCj144V5ee/JaKyT9/WZ0MGZWfA7A==",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.17.1.tgz",
+      "integrity": "sha512-BlYOpej8AQ8Ev9xVqroV7a02JK3SkBAaN9GfMMH9W6Ch8FlQlkjGw4Ir7+FgYwfirivAf4t+GtzuAxqfukmISA==",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.4",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.1.0.tgz",
+      "integrity": "sha512-4Bfj15dVJdoy3RfZmmo86RK1Fwzn6SstsvK9JS+BaVKqC6QQQQyXekNaC+g+LKNgkQ+2VhGAzm6hO40AhMR3zQ==",
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.9.0.tgz",
+      "integrity": "sha512-hhetes6ZHP3BlXLxmd8K2SNgkhNSi+UcecbnwWKwpP7kyi/uC75DJ1lOOBO3xrC4jyojtGE3YxKZPHfk4yrgug==",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.4.tgz",
+      "integrity": "sha512-BsWiH1yFGjXXS2yvrf5LyuoSIIbPrGUWob917o+BTKuZ7qJdxX8aJLRxs1fS9n6r7vESrq1OUqb68dANcFXuQQ==",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
     "node_modules/@fastify/busboy": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
       "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.0.tgz",
+      "integrity": "sha512-d2CGZR2o7fS6sWB7DG/3a95bGKQyHMACZ5aW8qGkkqQpUoZV6C0X7Pc7l4ZNMZkfNBf4VWNe9E1jRsf0G146Ew==",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
@@ -1370,7 +1495,6 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
         "run-parallel": "^1.1.9"
@@ -1383,7 +1507,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true,
       "engines": {
         "node": ">= 8"
       }
@@ -1392,7 +1515,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
@@ -2136,6 +2258,213 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.1.0.tgz",
+      "integrity": "sha512-LlNBaHFCEBPHyD4pZXb35mzjGkuGKXU5eeCA1SxvHfiRES0E82dOounfVpL4DCqYvJEKab0bZIA0gCRpdLKkCw==",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.10.0",
+        "@typescript-eslint/scope-manager": "8.1.0",
+        "@typescript-eslint/type-utils": "8.1.0",
+        "@typescript-eslint/utils": "8.1.0",
+        "@typescript-eslint/visitor-keys": "8.1.0",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.3.1",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^1.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.0.0 || ^8.0.0-alpha.0",
+        "eslint": "^8.57.0 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.1.0.tgz",
+      "integrity": "sha512-U7iTAtGgJk6DPX9wIWPPOlt1gO57097G06gIcl0N0EEnNw8RGD62c+2/DiP/zL7KrkqnnqF7gtFGR7YgzPllTA==",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.1.0",
+        "@typescript-eslint/types": "8.1.0",
+        "@typescript-eslint/typescript-estree": "8.1.0",
+        "@typescript-eslint/visitor-keys": "8.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.1.0.tgz",
+      "integrity": "sha512-DsuOZQji687sQUjm4N6c9xABJa7fjvfIdjqpSIIVOgaENf2jFXiM9hIBZOL3hb6DHK9Nvd2d7zZnoMLf9e0OtQ==",
+      "dependencies": {
+        "@typescript-eslint/types": "8.1.0",
+        "@typescript-eslint/visitor-keys": "8.1.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.1.0.tgz",
+      "integrity": "sha512-oLYvTxljVvsMnldfl6jIKxTaU7ok7km0KDrwOt1RHYu6nxlhN3TIx8k5Q52L6wR33nOwDgM7VwW1fT1qMNfFIA==",
+      "dependencies": {
+        "@typescript-eslint/typescript-estree": "8.1.0",
+        "@typescript-eslint/utils": "8.1.0",
+        "debug": "^4.3.4",
+        "ts-api-utils": "^1.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.1.0.tgz",
+      "integrity": "sha512-q2/Bxa0gMOu/2/AKALI0tCKbG2zppccnRIRCW6BaaTlRVaPKft4oVYPp7WOPpcnsgbr0qROAVCVKCvIQ0tbWog==",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.1.0.tgz",
+      "integrity": "sha512-NTHhmufocEkMiAord/g++gWKb0Fr34e9AExBRdqgWdVBaKoei2dIyYKD9Q0jBnvfbEA5zaf8plUFMUH6kQ0vGg==",
+      "dependencies": {
+        "@typescript-eslint/types": "8.1.0",
+        "@typescript-eslint/visitor-keys": "8.1.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^1.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.1.0.tgz",
+      "integrity": "sha512-ypRueFNKTIFwqPeJBfeIpxZ895PQhNyH4YID6js0UoBImWYoSjBsahUn9KMiJXh94uOjVBgHD9AmkyPsPnFwJA==",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@typescript-eslint/scope-manager": "8.1.0",
+        "@typescript-eslint/types": "8.1.0",
+        "@typescript-eslint/typescript-estree": "8.1.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.1.0.tgz",
+      "integrity": "sha512-ba0lNI19awqZ5ZNKh6wCModMwoZs457StTebQ0q1NP58zSi2F6MOZRXwfKZy+jB78JNJ/WH8GSh2IQNzXX8Nag==",
+      "dependencies": {
+        "@typescript-eslint/types": "8.1.0",
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/@vladfrangu/async_event_emitter": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.2.4.tgz",
@@ -2163,15 +2492,22 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.11.3",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
-      "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
-      "dev": true,
+      "version": "8.12.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
+      "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
       "bin": {
         "acorn": "bin/acorn"
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/acorn-walk": {
@@ -2192,6 +2528,21 @@
       },
       "engines": {
         "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/ansi-align": {
@@ -2274,6 +2625,11 @@
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "dev": true
     },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+    },
     "node_modules/array-back": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
@@ -2292,7 +2648,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
       "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -2595,6 +2950,14 @@
       "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==",
       "dev": true
     },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/camelcase": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-7.0.1.tgz",
@@ -2824,7 +3187,6 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
       "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-      "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -2849,6 +3211,11 @@
           "optional": true
         }
       }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
     },
     "node_modules/define-data-property": {
       "version": "1.1.4",
@@ -2927,7 +3294,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
       "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-      "dev": true,
       "dependencies": {
         "path-type": "^4.0.0"
       },
@@ -3173,6 +3539,166 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/eslint": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.9.0.tgz",
+      "integrity": "sha512-JfiKJrbx0506OEerjK2Y1QlldtBxkAlLxT5OEcRF8uaQ86noDe2k31Vw9rnSWv+MXZHj7OOUV/dA0AhdLFcyvA==",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.11.0",
+        "@eslint/config-array": "^0.17.1",
+        "@eslint/eslintrc": "^3.1.0",
+        "@eslint/js": "9.9.0",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.3.0",
+        "@nodelib/fs.walk": "^1.2.8",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.0.2",
+        "eslint-visitor-keys": "^4.0.0",
+        "espree": "^10.1.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "is-path-inside": "^3.0.3",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3",
+        "strip-ansi": "^6.0.1",
+        "text-table": "^0.2.0"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.0.2.tgz",
+      "integrity": "sha512-6E4xmrTw5wtxnLA5wYL3WDfhZ/1bUBGOXV0zQvVRDOtrR8D0p6W7fs3JweNYhwRYeGvd/1CKX2se0/2s7Q/nJA==",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.0.0.tgz",
+      "integrity": "sha512-OtIRv/2GyiF6o/d8K7MYKKbXrOUBIK6SfkIRM4Z0dY3w+LiQ0vy3F57m0Z71bjbyeiWFiHJ8brqnmE6H6/jEuw==",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.1.0.tgz",
+      "integrity": "sha512-M1M6CpiE6ffoigIOWYO9UDP8TMUw9kqb21tf+08IgDYjCsOvCuDt4jQcZmoYxx+w7zlKw9/N0KXfto+I8/FrXA==",
+      "dependencies": {
+        "acorn": "^8.12.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
+      "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
@@ -3266,7 +3792,6 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
       "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
-      "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -3277,6 +3802,16 @@
       "engines": {
         "node": ">=8.6.0"
       }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
     },
     "node_modules/fast-safe-stringify": {
       "version": "2.1.1",
@@ -3309,7 +3844,6 @@
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
       "integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
-      "dev": true,
       "dependencies": {
         "reusify": "^1.0.4"
       }
@@ -3342,6 +3876,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/file-type": {
@@ -3412,6 +3957,38 @@
       "engines": {
         "node": ">=4.0.0"
       }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
+      "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw=="
     },
     "node_modules/forwarded": {
       "version": "0.2.0",
@@ -3561,11 +4138,22 @@
         "node": ">= 6"
       }
     },
+    "node_modules/globals": {
+      "version": "15.9.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-15.9.0.tgz",
+      "integrity": "sha512-SmSKyLLKFbSr6rptvP8izbyxJL4ILwqO9Jg23UA0sDlGlu58V59D1//I3vlc0KJphVdUR7vMjHIplYnzBxorQA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/globby": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
       "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-      "dev": true,
       "dependencies": {
         "array-union": "^2.1.0",
         "dir-glob": "^3.0.1",
@@ -3591,6 +4179,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/graphemer": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag=="
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -3723,9 +4316,31 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
       "integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==",
-      "dev": true,
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "engines": {
+        "node": ">=0.8.19"
       }
     },
     "node_modules/inflight": {
@@ -3832,6 +4447,14 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-unicode-supported": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
@@ -3847,13 +4470,38 @@
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
     },
     "node_modules/jsbn": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
       "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A=="
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="
     },
     "node_modules/kareem": {
       "version": "2.5.1",
@@ -3863,12 +4511,46 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
     "node_modules/leven": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-4.0.0.tgz",
       "integrity": "sha512-puehA3YKku3osqPlNuzGDUHq8WpwXupUg1V6NXdV38G+gr+gkBwFC8g1b/+YcIvp8gnqVIus+eJCH/eGsRmJNw==",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -3884,6 +4566,11 @@
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
       "dev": true
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
     },
     "node_modules/lodash.snakecase": {
       "version": "4.1.1",
@@ -3973,7 +4660,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true,
       "engines": {
         "node": ">= 8"
       }
@@ -3990,7 +4676,6 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
       "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
-      "dev": true,
       "dependencies": {
         "braces": "^3.0.2",
         "picomatch": "^2.3.1"
@@ -4204,6 +4889,11 @@
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
     },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="
+    },
     "node_modules/negotiator": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
@@ -4319,6 +5009,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
@@ -4326,6 +5032,45 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/parse-cache-control": {
@@ -4341,6 +5086,14 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -4353,7 +5106,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -4367,7 +5119,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -4393,6 +5144,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/prism-media": {
@@ -4466,7 +5225,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4543,6 +5301,14 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
@@ -4569,7 +5335,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
-      "dev": true,
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
@@ -4602,7 +5367,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4770,7 +5534,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -4782,7 +5545,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -4818,7 +5580,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -4913,6 +5674,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/strnum": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
@@ -4961,6 +5733,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="
     },
     "node_modules/through": {
       "version": "2.3.8",
@@ -5045,6 +5822,17 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
+    "node_modules/ts-api-utils": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.3.0.tgz",
+      "integrity": "sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.2.0"
+      }
+    },
     "node_modules/ts-mixer": {
       "version": "6.0.4",
       "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz",
@@ -5117,6 +5905,17 @@
         "fsevents": "~2.3.3"
       }
     },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -5159,13 +5958,35 @@
       "version": "5.4.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
       "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
-      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.1.0.tgz",
+      "integrity": "sha512-prB2U3jXPJLpo1iVLN338Lvolh6OrcCZO+9Yv6AR+tvegPPptYCDBIHiEEUdqRi8gAv2bXNKfMUrgAd2ejn/ow==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.1.0",
+        "@typescript-eslint/parser": "8.1.0",
+        "@typescript-eslint/utils": "8.1.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/typical": {
@@ -5199,6 +6020,14 @@
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -5258,7 +6087,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -5341,6 +6169,14 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/word-list/-/word-list-1.0.1.tgz",
       "integrity": "sha512-f9TaupdTMV4Rmf6l2vw1O7P6nSqE8mOdIbGWddjcWQ11JoIdn+IMu8yCxeSp0LrCMJG2Qi1KE3ZcVN/QEPiE7Q==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5457,6 +6293,17 @@
         "node": ">=6"
       }
     },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/zumito-db": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/zumito-db/-/zumito-db-1.0.0.tgz",
@@ -5471,10 +6318,9 @@
       }
     },
     "node_modules/zumito-framework": {
-      "version": "1.1.72-dev-10395111434.0",
-      "resolved": "https://registry.npmjs.org/zumito-framework/-/zumito-framework-1.1.72-dev-10395111434.0.tgz",
-      "integrity": "sha512-d9SHYOUdi9t7wFm2gLHEJM2loK5b86B7FjdElRAZFBmBEjHqM00XuACYhVt7yHwqF8lCf2kCeR3ItJrYBmjqPA==",
-      "license": "ISC",
+      "version": "1.1.72-dev-10433285214.0",
+      "resolved": "https://registry.npmjs.org/zumito-framework/-/zumito-framework-1.1.72-dev-10433285214.0.tgz",
+      "integrity": "sha512-VJySi9WW6DuLo3PlX/RjDQLXzNuJHZjUPno35Rs9vAPSe8gbQC50vxaxNC0ZUP4+R2/mKCgmtrXpK+/1zDRk/Q==",
       "dependencies": {
         "@discordjs/rest": "^1.7.0",
         "@types/express": "^4.17.13",

--- a/package.json
+++ b/package.json
@@ -24,19 +24,25 @@
     "@discordjs/opus": "^0.9.0",
     "@discordjs/rest": "^1.7.0",
     "@discordjs/voice": "^0.16.0",
+    "@typescript-eslint/eslint-plugin": "^8.1.0",
+    "@typescript-eslint/parser": "^8.1.0",
     "discord.js": "^14.14.1",
     "dotenv": "^16.0.3",
     "ffmpeg-static": "^5.1.0",
     "fs-readdir-recursive": "^1.1.0",
-    "zumito-framework": "^1.1.72-dev-10395111434.0"
+    "zumito-framework": "^1.1.72-dev-10433285214.0"
   },
   "devDependencies": {
+    "@eslint/js": "^9.9.0",
     "@jsdevtools/version-bump-prompt": "^6.1.0",
     "@types/express": "^4.17.17",
     "@types/node": "^18.15.11",
+    "eslint": "^9.9.0",
+    "globals": "^15.9.0",
     "ts-node": "^10.9.1",
     "tsx": "^4.7.2",
-    "typescript": "^5.0.4"
+    "typescript": "^5.0.4",
+    "typescript-eslint": "^8.1.0"
   },
   "type": "module",
   "engines": {

--- a/src/modules/info/commands/help.ts
+++ b/src/modules/info/commands/help.ts
@@ -1,30 +1,41 @@
 import { ActionRowBuilder, AnyComponentBuilder, CommandInteraction, EmbedBuilder, StringSelectMenuBuilder } from "zumito-framework/discord";
-import { Command, CommandParameters, ZumitoFramework, CommandType, SelectMenuParameters, EmojiFallback, ButtonPressedParams } from "zumito-framework";
+import { Command, CommandParameters, ZumitoFramework, CommandType, SelectMenuParameters, EmojiFallback, ButtonPressedParams, ServiceContainer } from "zumito-framework";
 import { config } from "../../../config/index.js";
 import { ButtonBuilder, ButtonStyle, Client } from "discord.js";
 
 export class Help extends Command {
     categories = ["information"];
-    examples: string[] = ["", "ping", "avatar"];
+    examples = ["", "ping", "avatar"];
     aliases = ["?", "h"];
-    args: any = [{
-            name: "command",
-            type: "string",
-            optional: true,
-        }];
+    args = [{
+        name: "command",
+        type: "string",
+        optional: true,
+    }];
     botPermissions = [ "VIEW_CHANNEL", "SEND_MESSAGES", "EMBED_LINKS" ];
     userPermissions = [];
     type = CommandType.any;
 
-    execute({ message, interaction, args, client, framework, guildSettings }: CommandParameters): void {
+    client: Client;
+    framework: ZumitoFramework;
+    emojiFallback: EmojiFallback;
+
+    constructor() {
+        super();
+        this.client = ServiceContainer.getService(Client.name) as Client;
+        this.framework = ServiceContainer.getService(ZumitoFramework.name) as ZumitoFramework;
+        this.emojiFallback = ServiceContainer.getService(EmojiFallback) as EmojiFallback;
+    }
+
+    execute({ message, interaction, args, guildSettings }: CommandParameters): void {
 
         if (args.has("command")) {
 
-            if (framework.commands.getAll().has(args.get("command"))) {
+            if (this.framework.commands.getAll().has(args.get("command"))) {
 
-                let command: Command = framework.commands.get(args.get("command"))!;
-                const commandRow: any = new ActionRowBuilder().addComponents(this.getCategoriesSelectMenu(client, framework, guildSettings));
-                const commandEmbed = this.getCommandEmbed( framework, command, guildSettings );
+                const command: Command = this.framework.commands.get(args.get("command"))!;
+                const commandRow: any = new ActionRowBuilder().addComponents(this.getCategoriesSelectMenu(this.client, this.framework, guildSettings));
+                const commandEmbed = this.getCommandEmbed( this.framework, command, guildSettings );
                 (message || (interaction as unknown as CommandInteraction)).reply({
                     embeds: [commandEmbed],
                     components: [commandRow],
@@ -35,32 +46,32 @@ export class Help extends Command {
             }
         } else {
             const closeButton: any = new ButtonBuilder().setCustomId('help.close').setLabel('close').setStyle(ButtonStyle.Danger);
-            const row: any = new ActionRowBuilder().addComponents(this.getCategoriesSelectMenu(client, framework, guildSettings));
+            const row: any = new ActionRowBuilder().addComponents(this.getCategoriesSelectMenu(this.client, this.framework, guildSettings));
             const closeRow: any = new ActionRowBuilder().addComponents(closeButton)
             
-            let description = [
+            const description = [
 
-                framework.translations.get("command.help.greeting.0", guildSettings.lang,
+                this.framework.translations.get("command.help.greeting.0", guildSettings.lang,
                     {
-                        name: client!.user!.displayName
+                        name: this.client!.user!.displayName
                     }
                 ) 
                 
-                + ' ' + EmojiFallback.getEmoji(client, '', '😊'), '\n' +
+                + ' ' + this.emojiFallback.getEmoji('', '😊'), '\n' +
 
-                framework.translations.get("command.help.greeting.1", guildSettings.lang),
-                framework.translations.get("command.help.greeting.2", guildSettings.lang) + ' ' +EmojiFallback.getEmoji(client, '', '🎉'),
-                framework.translations.get("command.help.greeting.3", guildSettings.lang) + ' ' +EmojiFallback.getEmoji(client, '', '🎮') + ' ' +EmojiFallback.getEmoji(client, '', '🤖')
+                this.framework.translations.get("command.help.greeting.1", guildSettings.lang),
+                this.framework.translations.get("command.help.greeting.2", guildSettings.lang) + ' ' +this.emojiFallback.getEmoji('', '🎉'),
+                this.framework.translations.get("command.help.greeting.3", guildSettings.lang) + ' ' +this.emojiFallback.getEmoji('', '🎮') + ' ' +this.emojiFallback.getEmoji('', '🤖')
             ];
             
             const embed = new EmbedBuilder()
-            .setTitle(framework.translations.get("command.help.title", guildSettings.lang))
-            .setDescription(description.join('\n'))
-            .setColor(config.colors.default);
+                .setTitle(this.framework.translations.get("command.help.title", guildSettings.lang))
+                .setDescription(description.join('\n'))
+                .setColor(config.colors.default);
             
-            if (client && client.user) {
+            if (this.client && this.client.user) {
                 embed.setThumbnail(
-                    client.user.displayAvatarURL({ 
+                    this.client.user.displayAvatarURL({ 
                         forceStatic: false, 
                         size: 4096
                     })
@@ -77,9 +88,9 @@ export class Help extends Command {
         }
     }
 
-    async buttonPressed({ path, interaction, client, framework, guildSettings }: ButtonPressedParams): Promise<void> {
+    async buttonPressed({ path, interaction }: ButtonPressedParams): Promise<void> {
         if (path[1] == "close") {
-            await interaction.deleteReply();
+            await interaction.message.delete();
         }
     }
 
@@ -87,71 +98,71 @@ export class Help extends Command {
        
         if (path[1] == "category") {
             
-            let category: string = interaction.values[0];
+            const category: string = interaction.values[0];
 
-            let categoryEmbed = new EmbedBuilder()
+            const categoryEmbed = new EmbedBuilder()
             
-            .setAuthor({
-                name: framework.translations.get("command.help.commands_of", guildSettings.lang,
-                {
-                    name: client!.user!.displayName
-                }),
-                iconURL: client!.user!.displayAvatarURL(),
-            })
-
-            //EmojiFallback.getEmoji(client, framework.translations.get(`command.category.${category}.emoji`), framework.translations.get(`command.category.${category}.emoji`)
-            .addFields({
-                name: 'test'+ framework.translations.get(`global.category.${category}.name`, guildSettings.lang),
-                value: framework.translations.get("command.help.field.detailed", guildSettings.lang) + ": " + "" + "`" +
-                    this.getPrefix(guildSettings) + "help [command]" + "`" + "\n" + framework.translations.get("command.help.field.support", guildSettings.lang) + " [" + framework.translations.get("command.help.field.support_server", guildSettings.lang) + "](" + config.links.support + ")",
-            });
-                    
-            let commands: Command[] = Array.from(framework.commands.getAll().values()).filter((c: Command) => c.categories.includes(category));
-            let valuesToPush: string[] = [];
-            for (let i = 0; i < commands.length; i++) {
-                if (interaction.values[0] === "information" && i % 4 == 0) { i == 4 && categoryEmbed
-                    .addFields(
+                .setAuthor({
+                    name: framework.translations.get("command.help.commands_of", guildSettings.lang,
                         {
-                            name: EmojiFallback.getEmoji(client, '', "📖") + " " + framework.translations.get("command.help.commands", guildSettings.lang),
-                            value: "```" + 
-                            (commands[i]?.name || "") + Array(15 - commands[i]?.name.length).fill(" ").join('') + 
-                            (commands[i + 1]?.name || "") + Array(15 - (commands[i + 1]?.name?.length || 0)).fill(" ").join('') + 
-                            (commands[i + 2]?.name || "") + Array(15 - (commands[i + 2]?.name?.length || 0)).fill(" ").join('') + 
-                            (commands[i + 3]?.name || "")
-                            + valuesToPush.join("") + "```",
-                        }
-                    )
-                    .setColor(config.colors.default);
-                    
-                    i == 0 && valuesToPush.push(
+                            name: client!.user!.displayName
+                        }),
+                    iconURL: client!.user!.displayAvatarURL(),
+                })
 
-                        (commands[i]?.name || "") + Array(15 - commands[i]?.name.length).fill(" ").join('') + 
-                        (commands[i + 1]?.name || "") + Array(15 - commands[i + 1]?.name.length).fill(" ").join('') + 
-                        (commands[i + 2]?.name || "") + Array(15 - commands[i + 2]?.name.length).fill(" ").join('') + 
-                        (commands[i + 3]?.name || "")
-                        
+                .addFields({
+                    name: this.emojiFallback.getEmoji(framework.translations.get(`global.category.${category}.emoji`), this.framework.translations.get(`global.category.${category}.emoji`))+ ' ' + framework.translations.get(`global.category.${category}.name`, guildSettings.lang),
+                    value: framework.translations.get("command.help.field.detailed", guildSettings.lang) + ": " + "" + "`" +
+                    this.getPrefix(guildSettings) + "help [command]" + "`" + "\n" + framework.translations.get("command.help.field.support", guildSettings.lang) + " [" + framework.translations.get("command.help.field.support_server", guildSettings.lang) + "](" + config.links.support + ")",
+                });
+                    
+            const commands: Command[] = Array.from(framework.commands.getAll().values()).filter((c: Command) => c.categories.includes(category));
+            const valuesToPush: string[] = [];
+            for (let i = 0; i < commands.length; i++) {
+                if (interaction.values[0] === "information" && i % 4 == 0) { 
+                    if (i == 4) {
+                        categoryEmbed.addFields(
+                            {
+                                name: this.emojiFallback.getEmoji('', "📖") + " " + framework.translations.get("command.help.commands", guildSettings.lang),
+                                value: "```" + 
+                                    (commands[i]?.name || "") + Array(15 - commands[i]?.name.length).fill(" ").join('') + 
+                                    (commands[i + 1]?.name || "") + Array(15 - (commands[i + 1]?.name?.length || 0)).fill(" ").join('') + 
+                                    (commands[i + 2]?.name || "") + Array(15 - (commands[i + 2]?.name?.length || 0)).fill(" ").join('') + 
+                                    (commands[i + 3]?.name || "")
+                                    + valuesToPush.join("") + "```",
+                            }
+                        ).setColor(config.colors.default);
+                    }
+                    
+                    if (i == 0) { 
+                        valuesToPush.push(
+                            (commands[i]?.name || "") + Array(15 - commands[i]?.name.length).fill(" ").join('') + 
+                            (commands[i + 1]?.name || "") + Array(15 - commands[i + 1]?.name.length).fill(" ").join('') + 
+                            (commands[i + 2]?.name || "") + Array(15 - commands[i + 2]?.name.length).fill(" ").join('') + 
+                            (commands[i + 3]?.name || "")
                         );
+                    }
                 } else { 
                     if (i % 4 == 0) {
                         categoryEmbed
-                        .addFields(
-                            {
-                                name: EmojiFallback.getEmoji(client, '', "📖") + " " + framework.translations.get("command.help.commands", guildSettings.lang),
-                                value: "```" + 
+                            .addFields(
+                                {
+                                    name: this.emojiFallback.getEmoji('', "📖") + " " + framework.translations.get("command.help.commands", guildSettings.lang),
+                                    value: "```" + 
                                 (commands[i]?.name || "") + Array(15 - commands[i]?.name.length).fill(" ").join('') + 
                                 (commands[i + 1]?.name || "") + Array(15 - (commands[i + 1]?.name?.length || 0)).fill(" ").join('') + 
                                 (commands[i + 2]?.name || "") + Array(15 - (commands[i + 2]?.name?.length || 0)).fill(" ").join('') + 
                                 (commands[i + 3]?.name || "")
                                 + "       " + "```",
-                        }
-                        )
-                        .setColor(config.colors.default);
+                                }
+                            )
+                            .setColor(config.colors.default);
                     }
                 }
             }
                     
             const row1: any = new ActionRowBuilder().addComponents(this.getCategoriesSelectMenu(client, framework, guildSettings, category));
-            await interaction.deferUpdate();
+            //await interaction.deferUpdate();
             await interaction.editReply({
                 embeds: [categoryEmbed],
                 components: [row1],
@@ -162,12 +173,12 @@ export class Help extends Command {
                 
         } else if (path[1] == "command") {
                     
-            let command: Command | undefined = framework.commands.get(interaction.values[0]);
+            const command: Command | undefined = framework.commands.get(interaction.values[0]);
             
             const commandEmbed = this.getCommandEmbed( framework, command!, guildSettings );
             
             const row: any = new ActionRowBuilder()
-            .addComponents(this.getCategoriesSelectMenu(client, framework, guildSettings));
+                .addComponents(this.getCategoriesSelectMenu(client, framework, guildSettings));
             await interaction.deferUpdate();
             await interaction.editReply({
                 embeds: [commandEmbed],
@@ -179,121 +190,127 @@ export class Help extends Command {
         }
     }
             
-            getCategoriesSelectMenu( client: Client, framework: ZumitoFramework, guildSettings: any, selectedCategory?: string ): AnyComponentBuilder {
-                let categories: string[] = [];
-                framework.commands.getAll().forEach((command: Command) => {
-                    for (let category of command.categories) {
-                        if (!categories.includes(category)) {
-                            categories.push(category);
-                        }
-                    }
-                });
-                categories.sort();
-                
-                let selectMenuOptions: any = [];
-                
-                for (let category of categories) {
-                    let selectMenuOption: any = { 
-                        label: framework.translations.get(`global.category.${category}.name`, guildSettings.lang),
-                        value: category,
-                        description: framework.translations.get(`global.category.${category}.description`, guildSettings.lang)
-                    };
-                    
-                    if (EmojiFallback.getEmoji(client, framework.translations.get(`command.category.${category}.emoji`), framework.translations.get(`command.category.${category}.emoji`))) {
-                        selectMenuOption.emoji = EmojiFallback.getEmoji(client, framework.translations.get(`global.category.${category}.emoji`, guildSettings.lang), framework.translations.get(`global.category.${category}.emoji`, guildSettings.lang));
-                    }
-                    
-                    if (selectedCategory == category) {
-                        selectMenuOption.default = true;
-                    }
-                    
-                    selectMenuOptions.push(selectMenuOption);
+    getCategoriesSelectMenu( client: Client, framework: ZumitoFramework, guildSettings: any, selectedCategory?: string ): AnyComponentBuilder {
+        const categories: string[] = [];
+        framework.commands.getAll().forEach((command: Command) => {
+            for (const category of command.categories) {
+                if (!categories.includes(category)) {
+                    categories.push(category);
                 }
-                
-                return new StringSelectMenuBuilder()
-                .setCustomId("help.category")
-                .setPlaceholder(framework.translations.get("command.help.category", guildSettings.lang))
-                .addOptions(selectMenuOptions);
             }
-            
-            getCommandsSelectMenu(client: Client, framework: ZumitoFramework, category: string, guildSettings: any): AnyComponentBuilder {
+        });
+        categories.sort();
                 
-                let commands = Array.from(framework.commands.getAll().values()).filter((c: Command) => c.categories.includes(category));
-                let selectMenuOptions: any = [];
-                 for (let command of commands) {
-                    let selectMenuOption: any = {
-                        label: command.name,
-                        value: command.name,
-                        description: framework.translations.get(`command.${command.name}.description`, guildSettings.lang)
-                    };
+        const selectMenuOptions: any = [];
+                
+        for (const category of categories) {
+            const selectMenuOption: any = { 
+                label: framework.translations.get(`global.category.${category}.name`, guildSettings.lang),
+                value: category,
+                description: framework.translations.get(`global.category.${category}.description`, guildSettings.lang)
+            };
                     
-                    if (EmojiFallback.getEmoji(client, framework.translations.get(`command.category.${category}.emoji`), framework.translations.get(`command.category.${category}.emoji`))) 
-                    {
-                        selectMenuOption.emoji = EmojiFallback.getEmoji(client, framework.translations.get(`command.category.${category}.emoji`), framework.translations.get(`command.category.${category}.emoji`));
-                    }
-                    
-                    selectMenuOptions.push(selectMenuOption);
-                }
-                return new StringSelectMenuBuilder()
-                .setCustomId("help.command")
-                .setPlaceholder(framework.translations.get("command.help.select.command", guildSettings.lang))
-                .addOptions(selectMenuOptions);
+            if (this.emojiFallback.getEmoji(framework.translations.get(`command.category.${category}.emoji`), framework.translations.get(`command.category.${category}.emoji`))) {
+                selectMenuOption.emoji = this.emojiFallback.getEmoji(
+                    framework.translations.get(`global.category.${category}.emoji`, guildSettings.lang), 
+                    framework.translations.get(`global.category.${category}.emoji`, guildSettings.lang)
+                );
             }
+                    
+            if (selectedCategory == category) {
+                selectMenuOption.default = true;
+            }
+                    
+            selectMenuOptions.push(selectMenuOption);
+        }
+                
+        return new StringSelectMenuBuilder()
+            .setCustomId("help.category")
+            .setPlaceholder(framework.translations.get("command.help.category", guildSettings.lang))
+            .addOptions(selectMenuOptions);
+    }
             
-            getCommandEmbed( framework: ZumitoFramework, command: Command, guildSettings: any ): EmbedBuilder {
+    getCommandsSelectMenu(framework: ZumitoFramework, category: string, guildSettings: any): AnyComponentBuilder {
                 
-                let prefix = this.getPrefix(guildSettings);
-                let ussage: string = prefix + command.name + " ";
-                if (command.args && command.args.length > 0) {
-                    for (let arg of command.args) {
-                        if (arg.optional) {
-                            ussage += "<" + framework.translations.get(`command.${command.name}.arguments.${arg.name}.name`, guildSettings.lang) + ">";
-                        } else {
-                            ussage += "[" + framework.translations.get( `command.${command.name}.arguments.${arg.name}.name`, guildSettings.lang ) + "]";
-                        }
-                    }
-                }
+        const commands = Array.from(framework.commands.getAll().values()).filter((c: Command) => c.categories.includes(category));
+        const selectMenuOptions: any = [];
+        for (const command of commands) {
+            const selectMenuOption: any = {
+                label: command.name,
+                value: command.name,
+                description: framework.translations.get(`command.${command.name}.description`, guildSettings.lang)
+            };
+                    
+            if (this.emojiFallback.getEmoji(framework.translations.get(`command.category.${category}.emoji`), framework.translations.get(`command.category.${category}.emoji`))) 
+            {
+                selectMenuOption.emoji = this.emojiFallback.getEmoji(
+                    framework.translations.get(`command.category.${category}.emoji`), 
+                    framework.translations.get(`command.category.${category}.emoji`)
+                );
+            }
+                    
+            selectMenuOptions.push(selectMenuOption);
+        }
+        return new StringSelectMenuBuilder()
+            .setCustomId("help.command")
+            .setPlaceholder(framework.translations.get("command.help.select.command", guildSettings.lang))
+            .addOptions(selectMenuOptions);
+    }
+            
+    getCommandEmbed( framework: ZumitoFramework, command: Command, guildSettings: any ): EmbedBuilder {
                 
-                let examples: string[] = [];
-                if (command.examples && command.examples.length > 0) {
-                    for (let example of command.examples) {
-                        let commandText = command.aliases[Math.floor(Math.random() * command.aliases.length + 1)] || command.name; 
-                        examples.push(prefix + commandText + " " + example);
-                    }
+        const prefix = this.getPrefix(guildSettings);
+        let ussage: string = prefix + command.name + " ";
+        if (command.args && command.args.length > 0) {
+            for (const arg of command.args) {
+                if (arg.optional) {
+                    ussage += "<" + framework.translations.get(`command.${command.name}.arguments.${arg.name}.name`, guildSettings.lang) + ">";
+                } else {
+                    ussage += "[" + framework.translations.get( `command.${command.name}.arguments.${arg.name}.name`, guildSettings.lang ) + "]";
                 }
-                return new EmbedBuilder()
-                .setAuthor(
-                    {
-                        name:framework.translations.get("command.help.author.command", guildSettings.lang) + " " + `${command.name}`, 
-                        iconURL: framework.client.user!.displayAvatarURL(),
-                        url: "https://zumito.ga/commands/" + `${command.name}`
-                    })
-                    .setDescription(framework.translations.get(`command.${command.name}.description`, guildSettings.lang))
-                    .addFields(
-                        {
-                            name: framework.translations.get("command.help.usage", guildSettings.lang),
-                            value: "`" + (ussage || framework.translations.get("global.none", guildSettings.lang)) + "`",
-                        },
-                        {
-                            name: framework.translations.get("command.help.examples", guildSettings.lang),
-                            value: examples.join("\n") || framework.translations.get("command.help.noExamples", guildSettings.lang)
-                        },
-                        {
-                            name: framework.translations.get("command.help.aliases", guildSettings.lang),
-                            value: command.aliases.join(", ") || framework.translations.get("global.none", guildSettings.lang)
-                        },
-                        {
-                            name: framework.translations.get("command.help.permissions.bot", guildSettings.lang),
-                            value: (command?.botPermissions || []).map((p) => framework.translations.get(`global.permissions.${p}`)).join("\n") || framework.translations.get("global.none", guildSettings.lang),
-                            inline: true,
-                        },
-                        {
-                            name: framework.translations.get("command.help.permissions.user", guildSettings.lang),
-                            value: (command?.userPermissions || []).map((p) => framework.translations.get(`global.permissions.${p}`)).join("\n") || framework.translations.get("global.none", guildSettings.lang),
-                            inline: true,
-                        })
-                        .setColor(config.colors.default);
-                    }
+            }
+        }
+                
+        const examples: string[] = [];
+        if (command.examples && command.examples.length > 0) {
+            for (const example of command.examples) {
+                const commandText = command.aliases[Math.floor(Math.random() * command.aliases.length + 1)] || command.name; 
+                examples.push(prefix + commandText + " " + example);
+            }
+        }
+        return new EmbedBuilder()
+            .setAuthor(
+                {
+                    name:framework.translations.get("command.help.author.command", guildSettings.lang) + " " + `${command.name}`, 
+                    iconURL: framework.client.user!.displayAvatarURL(),
+                    url: "https://zumito.ga/commands/" + `${command.name}`
+                })
+            .setDescription(framework.translations.get(`command.${command.name}.description`, guildSettings.lang))
+            .addFields(
+                {
+                    name: framework.translations.get("command.help.usage", guildSettings.lang),
+                    value: "`" + (ussage || framework.translations.get("global.none", guildSettings.lang)) + "`",
+                },
+                {
+                    name: framework.translations.get("command.help.examples", guildSettings.lang),
+                    value: examples.join("\n") || framework.translations.get("command.help.noExamples", guildSettings.lang)
+                },
+                {
+                    name: framework.translations.get("command.help.aliases", guildSettings.lang),
+                    value: command.aliases.join(", ") || framework.translations.get("global.none", guildSettings.lang)
+                },
+                {
+                    name: framework.translations.get("command.help.permissions.bot", guildSettings.lang),
+                    value: (command?.botPermissions || []).map((p) => framework.translations.get(`global.permissions.${p}`)).join("\n") || framework.translations.get("global.none", guildSettings.lang),
+                    inline: true,
+                },
+                {
+                    name: framework.translations.get("command.help.permissions.user", guildSettings.lang),
+                    value: (command?.userPermissions || []).map((p) => framework.translations.get(`global.permissions.${p}`)).join("\n") || framework.translations.get("global.none", guildSettings.lang),
+                    inline: true,
+                })
+            .setColor(config.colors.default);
+    }
     
     getPrefix(guildSettings: any, framework?: ZumitoFramework): string {
         return ( guildSettings?.prefix || process.env.BOT_PREFIX || framework?.settings.defaultPrefix || "!");

--- a/src/modules/info/commands/help.ts
+++ b/src/modules/info/commands/help.ts
@@ -51,20 +51,8 @@ export class Help extends Command {
                 framework.translations.get("command.help.greeting.3", guildSettings.lang) + ' ' +EmojiFallback.getEmoji(client, '', '🎮') + ' ' +EmojiFallback.getEmoji(client, '', '🤖')
             ];
             
-            /*let description = [
-                
-                framework.translations.get("command.help.greeting.0", guildSettings.lang,
-                {
-                    name: client!.user!.displayName
-                }) + ' ' + EmojiFallback.getEmoji(client, '', '😊'),
-                
-                '\n'+ framework.translations.get("command.help.greeting.1", guildSettings.lang),
-                
-                framework.translations.get("command.help.greeting.2", guildSettings.lang)
-            ];*/
-            
             const embed = new EmbedBuilder()
-            //.setTitle(framework.translations.get("command.help.title", guildSettings.lang))
+            .setTitle(framework.translations.get("command.help.title", guildSettings.lang))
             .setDescription(description.join('\n'))
             .setColor(config.colors.default);
             

--- a/src/modules/info/commands/help.ts
+++ b/src/modules/info/commands/help.ts
@@ -1,6 +1,7 @@
 import { ActionRowBuilder, AnyComponentBuilder, CommandInteraction, EmbedBuilder, StringSelectMenuBuilder } from "zumito-framework/discord";
-import { Command, CommandParameters, ZumitoFramework, CommandType, SelectMenuParameters, EmojiFallback } from "zumito-framework";
+import { Command, CommandParameters, ZumitoFramework, CommandType, SelectMenuParameters, EmojiFallback, ButtonPressedParams } from "zumito-framework";
 import { config } from "../../../config/index.js";
+import { ButtonBuilder, ButtonStyle } from "discord.js";
 
 export class Help extends Command {
     categories = ["information"];
@@ -33,8 +34,9 @@ export class Help extends Command {
                 });
             }
         } else {
-            
+            const closeButton: any = new ButtonBuilder().setCustomId('help.close').setLabel('close').setStyle(ButtonStyle.Danger);
             const row: any = new ActionRowBuilder().addComponents(this.getCategoriesSelectMenu(framework, guildSettings));
+            const closeRow: any = new ActionRowBuilder().addComponents(closeButton)
             
             let description = [
 
@@ -67,7 +69,7 @@ export class Help extends Command {
 
             (message || (interaction as unknown as CommandInteraction)).reply({
                 embeds: [embed],
-                components: [row],
+                components: [row, closeRow],
                 allowedMentions: {
                     repliedUser: false,
                 },
@@ -75,105 +77,104 @@ export class Help extends Command {
         }
     }
 
+    async buttonPressed({ path, interaction, client, framework, guildSettings }: ButtonPressedParams): Promise<void> {
+        if (path[1] == "close") {
+            await interaction.deleteReply();
+        }
+    }
+
     async selectMenu({ path, interaction, client, framework, guildSettings }: SelectMenuParameters): Promise<void> {
-        
         if (path[1] == "category") {
             
             let category: string = interaction.values[0];
 
             let categoryEmbed = new EmbedBuilder()
             
-            .setAuthor(
+            .setAuthor({
+                name: framework.translations.get("command.help.commands_of", guildSettings.lang,
                 {
-                    name: framework.translations.get("command.help.commands_of", guildSettings.lang,
-                    {
-                        name: client!.user!.displayName
-                    }),
-                    iconURL: client!.user!.displayAvatarURL(),
-                })
-
-                .addFields(
-                    {
-                        name: category,
-                        value: framework.translations.get("command.help.field.detailed", guildSettings.lang) + ": " + "" + "`" +
-                            this.getPrefix(guildSettings) + "help [command]" + "`" + "\n" + framework.translations.get("command.help.field.support", guildSettings.lang) + " [" + framework.translations.get("command.help.field.support_server", guildSettings.lang) + "](" + config.links.support + ")",
-                    });
+                    name: client!.user!.displayName
+                }),
+                iconURL: client!.user!.displayAvatarURL(),
+            })
+            .addFields({
+                name: category,
+                value: framework.translations.get("command.help.field.detailed", guildSettings.lang) + ": " + "" + "`" +
+                    this.getPrefix(guildSettings) + "help [command]" + "`" + "\n" + framework.translations.get("command.help.field.support", guildSettings.lang) + " [" + framework.translations.get("command.help.field.support_server", guildSettings.lang) + "](" + config.links.support + ")",
+            });
                     
-                    let commands: Command[] = Array.from(framework.commands.getAll().values()).filter((c: Command) => c.categories.includes(category));
-                    let valuesToPush: string[] = [];
-                    for (let i = 0; i < commands.length; i++) 
-                    {
-                        if (interaction.values[0] === "information" && i % 4 == 0) { i == 4 && categoryEmbed
-                            .addFields(
-                                {
-                                    name: "📖" + " " + framework.translations.get("command.help.commands", guildSettings.lang),
-                                    value: "```" + 
-                                    (commands[i]?.name || "") + Array(15 - commands[i]?.name.length).fill(" ").join('') + 
-                                    (commands[i + 1]?.name || "") + Array(15 - (commands[i + 1]?.name?.length || 0)).fill(" ").join('') + 
-                                    (commands[i + 2]?.name || "") + Array(15 - (commands[i + 2]?.name?.length || 0)).fill(" ").join('') + 
-                                    (commands[i + 3]?.name || "")
-                                    + valuesToPush.join("") + "```",
-                                }
-                            )
-                            .setColor(config.colors.default);
-                            
-                            i == 0 && valuesToPush.push(
+            let commands: Command[] = Array.from(framework.commands.getAll().values()).filter((c: Command) => c.categories.includes(category));
+            let valuesToPush: string[] = [];
+            for (let i = 0; i < commands.length; i++) {
+                if (interaction.values[0] === "information" && i % 4 == 0) { i == 4 && categoryEmbed
+                    .addFields(
+                        {
+                            name: "📖" + " " + framework.translations.get("command.help.commands", guildSettings.lang),
+                            value: "```" + 
+                            (commands[i]?.name || "") + Array(15 - commands[i]?.name.length).fill(" ").join('') + 
+                            (commands[i + 1]?.name || "") + Array(15 - (commands[i + 1]?.name?.length || 0)).fill(" ").join('') + 
+                            (commands[i + 2]?.name || "") + Array(15 - (commands[i + 2]?.name?.length || 0)).fill(" ").join('') + 
+                            (commands[i + 3]?.name || "")
+                            + valuesToPush.join("") + "```",
+                        }
+                    )
+                    .setColor(config.colors.default);
+                    
+                    i == 0 && valuesToPush.push(
 
+                        (commands[i]?.name || "") + Array(15 - commands[i]?.name.length).fill(" ").join('') + 
+                        (commands[i + 1]?.name || "") + Array(15 - commands[i + 1]?.name.length).fill(" ").join('') + 
+                        (commands[i + 2]?.name || "") + Array(15 - commands[i + 2]?.name.length).fill(" ").join('') + 
+                        (commands[i + 3]?.name || "")
+                        
+                        );
+                } else { 
+                    if (i % 4 == 0) {
+                        categoryEmbed
+                        .addFields(
+                            {
+                                name: "📖" + " " + framework.translations.get("command.help.commands", guildSettings.lang),
+                                value: "```" + 
                                 (commands[i]?.name || "") + Array(15 - commands[i]?.name.length).fill(" ").join('') + 
-                                (commands[i + 1]?.name || "") + Array(15 - commands[i + 1]?.name.length).fill(" ").join('') + 
-                                (commands[i + 2]?.name || "") + Array(15 - commands[i + 2]?.name.length).fill(" ").join('') + 
+                                (commands[i + 1]?.name || "") + Array(15 - (commands[i + 1]?.name?.length || 0)).fill(" ").join('') + 
+                                (commands[i + 2]?.name || "") + Array(15 - (commands[i + 2]?.name?.length || 0)).fill(" ").join('') + 
                                 (commands[i + 3]?.name || "")
-                                
-                                );
-                        } else { 
-                            if (i % 4 == 0) {
-                                categoryEmbed
-                                .addFields(
-                                    {
-                                        name: "📖" + " " + framework.translations.get("command.help.commands", guildSettings.lang),
-                                        value: "```" + 
-                                        (commands[i]?.name || "") + Array(15 - commands[i]?.name.length).fill(" ").join('') + 
-                                        (commands[i + 1]?.name || "") + Array(15 - (commands[i + 1]?.name?.length || 0)).fill(" ").join('') + 
-                                        (commands[i + 2]?.name || "") + Array(15 - (commands[i + 2]?.name?.length || 0)).fill(" ").join('') + 
-                                        (commands[i + 3]?.name || "")
-                                        + "       " + "```",
-                                }
-                                )
-                                .setColor(config.colors.default);
-                            }
+                                + "       " + "```",
                         }
+                        )
+                        .setColor(config.colors.default);
                     }
-                    
-                    const row1: any = new ActionRowBuilder().addComponents(this.getCategoriesSelectMenu(framework, guildSettings, category));
-                    await interaction.deferUpdate();
-                    await interaction.editReply({
-                        embeds: [categoryEmbed],
-                        components: [row1],
-                        allowedMentions: {
-                            repliedUser: false
-                        }
-                    });
-                
-                } else 
-                
-                if (path[1] == "command") {
-                    
-                    let command: Command | undefined = framework.commands.get(interaction.values[0]);
-                    
-                    const commandEmbed = this.getCommandEmbed( framework, command!, guildSettings );
-                    
-                    const row: any = new ActionRowBuilder()
-                    .addComponents(this.getCategoriesSelectMenu(framework, guildSettings));
-                    await interaction.deferUpdate();
-                    await interaction.editReply({
-                        embeds: [commandEmbed],
-                        components: [row],
-                        allowedMentions: {
-                            repliedUser: false
-                        }
-                    });
                 }
             }
+                    
+            const row1: any = new ActionRowBuilder().addComponents(this.getCategoriesSelectMenu(framework, guildSettings, category));
+            await interaction.deferUpdate();
+            await interaction.editReply({
+                embeds: [categoryEmbed],
+                components: [row1],
+                allowedMentions: {
+                    repliedUser: false
+                }
+            });
+                
+        } else if (path[1] == "command") {
+                    
+            let command: Command | undefined = framework.commands.get(interaction.values[0]);
+            
+            const commandEmbed = this.getCommandEmbed( framework, command!, guildSettings );
+            
+            const row: any = new ActionRowBuilder()
+            .addComponents(this.getCategoriesSelectMenu(framework, guildSettings));
+            await interaction.deferUpdate();
+            await interaction.editReply({
+                embeds: [commandEmbed],
+                components: [row],
+                allowedMentions: {
+                    repliedUser: false
+                }
+            });
+        }
+    }
             
             getCategoriesSelectMenu( framework: ZumitoFramework, guildSettings: any, selectedCategory?: string ): AnyComponentBuilder {
                 let categories: string[] = [];

--- a/src/modules/info/commands/help.ts
+++ b/src/modules/info/commands/help.ts
@@ -109,7 +109,7 @@ export class Help extends Command {
                 if (interaction.values[0] === "information" && i % 4 == 0) { i == 4 && categoryEmbed
                     .addFields(
                         {
-                            name: "📖" + " " + framework.translations.get("command.help.commands", guildSettings.lang),
+                            name: EmojiFallback.getEmoji(client, '', "📖") + " " + framework.translations.get("command.help.commands", guildSettings.lang),
                             value: "```" + 
                             (commands[i]?.name || "") + Array(15 - commands[i]?.name.length).fill(" ").join('') + 
                             (commands[i + 1]?.name || "") + Array(15 - (commands[i + 1]?.name?.length || 0)).fill(" ").join('') + 
@@ -133,7 +133,7 @@ export class Help extends Command {
                         categoryEmbed
                         .addFields(
                             {
-                                name: "📖" + " " + framework.translations.get("command.help.commands", guildSettings.lang),
+                                name: EmojiFallback.getEmoji(client, '', "📖") + " " + framework.translations.get("command.help.commands", guildSettings.lang),
                                 value: "```" + 
                                 (commands[i]?.name || "") + Array(15 - commands[i]?.name.length).fill(" ").join('') + 
                                 (commands[i + 1]?.name || "") + Array(15 - (commands[i + 1]?.name?.length || 0)).fill(" ").join('') + 

--- a/src/modules/info/commands/help.ts
+++ b/src/modules/info/commands/help.ts
@@ -1,7 +1,7 @@
 import { ActionRowBuilder, AnyComponentBuilder, CommandInteraction, EmbedBuilder, StringSelectMenuBuilder } from "zumito-framework/discord";
 import { Command, CommandParameters, ZumitoFramework, CommandType, SelectMenuParameters, EmojiFallback, ButtonPressedParams } from "zumito-framework";
 import { config } from "../../../config/index.js";
-import { ButtonBuilder, ButtonStyle } from "discord.js";
+import { ButtonBuilder, ButtonStyle, Client } from "discord.js";
 
 export class Help extends Command {
     categories = ["information"];
@@ -23,7 +23,7 @@ export class Help extends Command {
             if (framework.commands.getAll().has(args.get("command"))) {
 
                 let command: Command = framework.commands.get(args.get("command"))!;
-                const commandRow: any = new ActionRowBuilder().addComponents(this.getCategoriesSelectMenu(framework, guildSettings));
+                const commandRow: any = new ActionRowBuilder().addComponents(this.getCategoriesSelectMenu(client, framework, guildSettings));
                 const commandEmbed = this.getCommandEmbed( framework, command, guildSettings );
                 (message || (interaction as unknown as CommandInteraction)).reply({
                     embeds: [commandEmbed],
@@ -35,7 +35,7 @@ export class Help extends Command {
             }
         } else {
             const closeButton: any = new ButtonBuilder().setCustomId('help.close').setLabel('close').setStyle(ButtonStyle.Danger);
-            const row: any = new ActionRowBuilder().addComponents(this.getCategoriesSelectMenu(framework, guildSettings));
+            const row: any = new ActionRowBuilder().addComponents(this.getCategoriesSelectMenu(client, framework, guildSettings));
             const closeRow: any = new ActionRowBuilder().addComponents(closeButton)
             
             let description = [
@@ -84,6 +84,7 @@ export class Help extends Command {
     }
 
     async selectMenu({ path, interaction, client, framework, guildSettings }: SelectMenuParameters): Promise<void> {
+       
         if (path[1] == "category") {
             
             let category: string = interaction.values[0];
@@ -97,8 +98,10 @@ export class Help extends Command {
                 }),
                 iconURL: client!.user!.displayAvatarURL(),
             })
+
+            //EmojiFallback.getEmoji(client, framework.translations.get(`command.category.${category}.emoji`), framework.translations.get(`command.category.${category}.emoji`)
             .addFields({
-                name: category,
+                name: 'test'+ framework.translations.get(`global.category.${category}.name`, guildSettings.lang),
                 value: framework.translations.get("command.help.field.detailed", guildSettings.lang) + ": " + "" + "`" +
                     this.getPrefix(guildSettings) + "help [command]" + "`" + "\n" + framework.translations.get("command.help.field.support", guildSettings.lang) + " [" + framework.translations.get("command.help.field.support_server", guildSettings.lang) + "](" + config.links.support + ")",
             });
@@ -147,7 +150,7 @@ export class Help extends Command {
                 }
             }
                     
-            const row1: any = new ActionRowBuilder().addComponents(this.getCategoriesSelectMenu(framework, guildSettings, category));
+            const row1: any = new ActionRowBuilder().addComponents(this.getCategoriesSelectMenu(client, framework, guildSettings, category));
             await interaction.deferUpdate();
             await interaction.editReply({
                 embeds: [categoryEmbed],
@@ -164,7 +167,7 @@ export class Help extends Command {
             const commandEmbed = this.getCommandEmbed( framework, command!, guildSettings );
             
             const row: any = new ActionRowBuilder()
-            .addComponents(this.getCategoriesSelectMenu(framework, guildSettings));
+            .addComponents(this.getCategoriesSelectMenu(client, framework, guildSettings));
             await interaction.deferUpdate();
             await interaction.editReply({
                 embeds: [commandEmbed],
@@ -176,7 +179,7 @@ export class Help extends Command {
         }
     }
             
-            getCategoriesSelectMenu( framework: ZumitoFramework, guildSettings: any, selectedCategory?: string ): AnyComponentBuilder {
+            getCategoriesSelectMenu( client: Client, framework: ZumitoFramework, guildSettings: any, selectedCategory?: string ): AnyComponentBuilder {
                 let categories: string[] = [];
                 framework.commands.getAll().forEach((command: Command) => {
                     for (let category of command.categories) {
@@ -191,13 +194,13 @@ export class Help extends Command {
                 
                 for (let category of categories) {
                     let selectMenuOption: any = { 
-                        label: framework.translations.get(`global.category.${category}.emoji`, guildSettings.lang) + " " + framework.translations.get(`global.category.${category}.name`, guildSettings.lang),
+                        label: framework.translations.get(`global.category.${category}.name`, guildSettings.lang),
                         value: category,
                         description: framework.translations.get(`global.category.${category}.description`, guildSettings.lang)
                     };
                     
-                    if (framework.translations.has(`command.category.${category}.emoji`)) {
-                        selectMenuOption.emoji = framework.translations.get(`global.category.${category}.emoji`, guildSettings.lang);
+                    if (EmojiFallback.getEmoji(client, framework.translations.get(`command.category.${category}.emoji`), framework.translations.get(`command.category.${category}.emoji`))) {
+                        selectMenuOption.emoji = EmojiFallback.getEmoji(client, framework.translations.get(`global.category.${category}.emoji`, guildSettings.lang), framework.translations.get(`global.category.${category}.emoji`, guildSettings.lang));
                     }
                     
                     if (selectedCategory == category) {
@@ -213,7 +216,7 @@ export class Help extends Command {
                 .addOptions(selectMenuOptions);
             }
             
-            getCommandsSelectMenu(framework: ZumitoFramework, category: string, guildSettings: any): AnyComponentBuilder {
+            getCommandsSelectMenu(client: Client, framework: ZumitoFramework, category: string, guildSettings: any): AnyComponentBuilder {
                 
                 let commands = Array.from(framework.commands.getAll().values()).filter((c: Command) => c.categories.includes(category));
                 let selectMenuOptions: any = [];
@@ -224,9 +227,9 @@ export class Help extends Command {
                         description: framework.translations.get(`command.${command.name}.description`, guildSettings.lang)
                     };
                     
-                    if (framework.translations.has(`command.category.${category}.emoji`)) 
+                    if (EmojiFallback.getEmoji(client, framework.translations.get(`command.category.${category}.emoji`), framework.translations.get(`command.category.${category}.emoji`))) 
                     {
-                        selectMenuOption.emoji = framework.translations.get(`command.category.${category}.emoji`, guildSettings.lang);
+                        selectMenuOption.emoji = EmojiFallback.getEmoji(client, framework.translations.get(`command.category.${category}.emoji`), framework.translations.get(`command.category.${category}.emoji`));
                     }
                     
                     selectMenuOptions.push(selectMenuOption);

--- a/src/modules/info/translations/command/help/en.json
+++ b/src/modules/info/translations/command/help/en.json
@@ -29,7 +29,9 @@
     "select": {
         "command": "Select a command"
     },
-    
+    "button": {
+        "close": "❌"
+    },
     "arguments": {
         "command": {
             "name": "command",

--- a/src/modules/info/translations/command/help/es.json
+++ b/src/modules/info/translations/command/help/es.json
@@ -27,7 +27,9 @@
     "select": {
         "command": "Selecciona un comando"
     },
-    
+    "button": {
+        "close": "❌"
+    },
     "arguments": {
         "command": {
             "name": "comando",

--- a/src/modules/info/translations/command/help/es.json
+++ b/src/modules/info/translations/command/help/es.json
@@ -11,7 +11,7 @@
     "author": {
         "command": "Comando"
     },
-    "commands_of": "Comandos de {name]",
+    "commands_of": "Comandos de {name}",
     "commands": "Comandos",
     "usage": "Uso",
     "examples": "Ejemplos",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,6 +23,9 @@
         "lib": [
             "ESNext"
         ],
+        "paths": {
+            "@config/*": ["./src/config/*"]
+        }
     },
     "ts-node": {
         "compilerOptions": {


### PR DESCRIPTION
Changes made:

- A button was added in order to limit the session message of categories and commands.

- A new translation was added with the key: button.close. This was assigned to the button mentioned above.

- The 70% of framework.translations.get(' ', guildSettings.lang) was changed to trans(' ').

- Revamped the message sent to use the z-help. 

- Fixed selectmenu emojis are now displayed correctly. 

- Corrected the translation of selectmenu now shows correctly.

- Added EmojiFallback service to show emojis correctly.