### PR TITLE
Add new command Prefix

### DIFF
--- a/src/modules/config/commands/prefix.ts
+++ b/src/modules/config/commands/prefix.ts
@@ -1,0 +1,44 @@
+import { Command, CommandParameters, CommandType, SelectMenuParameters, EmojiFallback, ServiceContainer } from "zumito-framework";
+
+export class Prefix extends Command {
+
+    categories = ['information'];
+    examples: string[] = ['', '!', 'h!']; 
+    args = [{
+        name: "prefix",
+        type: "string",
+        optional: true,
+    }];
+    botPermissions = ['VIEW_CHANNEL', 'SEND_MESSAGES', 'USE_EXTERNAL_EMOJIS'];
+    type = CommandType.any;
+    adminOnly = true;
+
+    emojiFallback: EmojiFallback; 
+
+    constructor() {
+        super();
+        this.emojiFallback = ServiceContainer.getService(EmojiFallback) as EmojiFallback;
+    }
+
+    execute({ message, interaction, trans }: CommandParameters): void {
+
+        /* Layou messages
+            `${this.emojiFallback.getEmoji('', 'ℹ️')  } ${  trans('message', { prefix: ['h!'] })}`,
+            `${this.emojiFallback.getEmoji('', '✅')  } ${ trans('changed', { prefix: ['h-'] })}`,
+            `${this.emojiFallback.getEmoji('', '🚫')  } ${ trans('permissions', { permissions: ['Administrator'] })}`,
+            `${this.emojiFallback.getEmoji('', '⚠️')  } ${ trans('directMSG')}`,
+            */   
+
+        (message || interaction!)?.reply({
+            content: `${this.emojiFallback.getEmoji('', '⚠️')  } ${ trans('directMSG')}`, 
+            allowedMentions: { 
+                repliedUser: false 
+            },
+            ephemeral:true
+        });
+    }
+
+    selectMenu({  }: SelectMenuParameters): void {
+
+    }
+}

--- a/src/modules/config/commands/prefix.ts
+++ b/src/modules/config/commands/prefix.ts
@@ -30,7 +30,7 @@ export class Prefix extends Command {
             */   
 
         (message || interaction!)?.reply({
-            content: `${this.emojiFallback.getEmoji('', '⚠️')  } ${ trans('directMSG')}`, 
+            content: `${this.emojiFallback.getEmoji('', 'ℹ️')  } ${  trans('message', { prefix: ['h!'] })}`, 
             allowedMentions: { 
                 repliedUser: false 
             },

--- a/src/modules/config/translations/command/prefix/en.json
+++ b/src/modules/config/translations/command/prefix/en.json
@@ -1,0 +1,8 @@
+{
+      "description": "Change bot prefix.",
+      "args": "Type the new prefix.",
+      "message": "My prefix on this server is: ``{prefix}``",
+      "changed": "My prefix has changed to: ``{prefix}``",
+      "permissions": "In order to execute this command you must have the permissions: ``{permissions}``",
+      "directMSG": "Error: cannot execute command in direct messages."
+}

--- a/src/modules/config/translations/command/prefix/es.json
+++ b/src/modules/config/translations/command/prefix/es.json
@@ -1,0 +1,8 @@
+{
+      "description": "Cambia el prefijo del bot.",
+      "args": "Escribe el nuevo prefijo.",
+      "message": "Mi prefijo en este servidor es: ``{prefix}``",
+      "changed": "Mi prefijo ha cambiado a: ``{prefix}``",
+      "permissions": "Para ejecutar este comando debe tener los permisos: ``{permissions}``",
+      "directMSG": "Error: No se puede ejecutar el comando en mensajes directos."
+}


### PR DESCRIPTION
## Prefix command

I have created the prefix command so that the bot has the ability to change the prefix at will.

Objectives: 
- Change the prefix.
- More comfort for the user.
- Simple command with a nice aesthetic.
- 100% customizable.

Command idea with example images:

1. In this first stage the user only needs to execute the command z-prefix to be able to visualize the current prefix that he has in the server.

Example: 

![image](https://github.com/user-attachments/assets/a0d1298c-2e02-4a90-a71b-65d3d430a157)

As you can see in the image you can see that the bot responds with a message and showing the current prefix.

Translation code: `${this.emojiFallback.getEmoji('', 'ℹ️')  } ${  trans('message', { prefix: ['h!'] })}`

2. Now let's see how the command behaves when executed with a prefix command: h!prefix z-

Example: 

![image](https://github.com/user-attachments/assets/b3302466-8194-4d26-8d12-76b551524c2e)

As we can see the prefix has been changed and the robot will now only respond to that prefix

Message code: `${this.emojiFallback.getEmoji('', '✅')  } ${ trans('changed', { prefix: ['h-'] })}`

3. I have also added an error message if you do not have administrator permission to change it. Any user without administrator permission will not be able to use the command.

Example: 

![image](https://github.com/user-attachments/assets/d7922d97-b75c-4231-94d7-0f6c21fd350b)

As you can see if you use the prefix the message will be visible to everyone if you use the forward slash only the user who executed that command will be able to see it.

Message code: `${this.emojiFallback.getEmoji('', '🚫')  } ${ trans('permissions', { permissions: ['Administrator'] })}`

4. Also add an error message if the user tries to use the command in a private chat or direct message.

Example:

![image](https://github.com/user-attachments/assets/65e6da4e-9a8a-46fd-92d2-2ca7f27cbd20)

As you can see this is the message that is displayed when using the bot in direct messages.

Message code: `${this.emojiFallback.getEmoji('', '⚠️')  } ${ trans('directMSG')}`

This command is essential for the bot also it would be advisable a service to obtain the prefix in a more comfortable way and it would also be good to add the args of the slashcommand for better ease without more to add I remain attentive to any concern