### PR TITLE
Add welcome module

### DIFF
--- a/src/modules/welcome/commands/setwelcome.ts
+++ b/src/modules/welcome/commands/setwelcome.ts
@@ -1,0 +1,38 @@
+import { Command, CommandParameters } from 'zumito-framework';
+import { PermissionsBitField, TextChannel } from 'zumito-framework/discord';
+import { ZumitoFramework } from 'zumito-framework';
+
+export class SetWelcomeCommand extends Command {
+    name = 'setwelcome';
+    description = 'Configure welcome channel and message';
+    categories = ['configuration'];
+    userPermissions: bigint[] = [PermissionsBitField.Flags.Administrator];
+    args = [
+        { name: 'channel', type: 'channel', optional: false },
+        { name: 'message', type: 'string', optional: false }
+    ];
+
+    async execute({ message, interaction, args, framework }: CommandParameters) {
+        const guild = message?.guild || interaction?.guild;
+        const channel = args.get('channel') as TextChannel;
+        const welcomeMessage = args.get('message');
+        if (!guild || !channel || !welcomeMessage) {
+            const reply = 'Missing channel or message.';
+            if (interaction) await interaction.reply({ content: reply, ephemeral: true });
+            else if (message) await message.reply(reply);
+            return;
+        }
+        const model = framework.database.models.WelcomeConfig;
+        let config = await model.findOne({ where: { guildId: guild.id } });
+        if (!config) {
+            config = await model.create({ guildId: guild.id, channelId: channel.id, message: welcomeMessage });
+        } else {
+            config.channelId = channel.id;
+            config.message = welcomeMessage;
+            await config.save();
+        }
+        const reply = `Welcome message configured for <#${channel.id}>`;
+        if (interaction) await interaction.reply({ content: reply, ephemeral: true });
+        else if (message) await message.reply(reply);
+    }
+}

--- a/src/modules/welcome/index.ts
+++ b/src/modules/welcome/index.ts
@@ -1,0 +1,9 @@
+import { Module, ServiceContainer, ZumitoFramework } from "zumito-framework";
+import { WelcomeService } from "./services/WelcomeService";
+
+export class WelcomeModule extends Module {
+    constructor(modulePath: string, framework: ZumitoFramework) {
+        super(modulePath);
+        ServiceContainer.addService(WelcomeService, [], true);
+    }
+}

--- a/src/modules/welcome/models/WelcomeConfig.ts
+++ b/src/modules/welcome/models/WelcomeConfig.ts
@@ -1,0 +1,26 @@
+import { DatabaseModel } from 'zumito-framework';
+
+export class WelcomeConfig extends DatabaseModel {
+    getModel(schema: any) {
+        return {
+            guildId: {
+                type: schema.String,
+                required: true,
+                unique: true
+            },
+            channelId: {
+                type: schema.String,
+                required: true
+            },
+            message: {
+                type: schema.String,
+                required: true,
+                default: 'Welcome {user}!'
+            }
+        };
+    }
+
+    define(model: any, models: any): void {
+        model.validatesUniquenessOf('guildId');
+    }
+}

--- a/src/modules/welcome/services/WelcomeService.ts
+++ b/src/modules/welcome/services/WelcomeService.ts
@@ -1,0 +1,27 @@
+import { Client, TextBasedChannel } from 'zumito-framework/discord';
+import { ServiceContainer, ZumitoFramework } from 'zumito-framework';
+
+export class WelcomeService {
+    private client: Client;
+    private framework: ZumitoFramework;
+
+    constructor() {
+        this.client = ServiceContainer.getService(Client);
+        this.framework = ServiceContainer.getService(ZumitoFramework);
+        this.registerEvents();
+    }
+
+    private registerEvents() {
+        this.client.on('guildMemberAdd', async (member) => {
+            const WelcomeModel = this.framework.database.models.WelcomeConfig;
+            if (!WelcomeModel) return;
+            const config = await WelcomeModel.findOne({ where: { guildId: member.guild.id } });
+            if (!config) return;
+            const channel = member.guild.channels.cache.get(config.channelId) as TextBasedChannel | undefined;
+            if (!channel || !('send' in channel)) return;
+            let content = config.message || '';
+            content = content.replace('{user}', `<@${member.id}>`).replace('{server}', member.guild.name);
+            await (channel as any).send({ content });
+        });
+    }
+}

--- a/src/modules/welcome/translations/command/setwelcome/en.json
+++ b/src/modules/welcome/translations/command/setwelcome/en.json
@@ -1,0 +1,14 @@
+{
+    "description": "Configure the welcome channel and message.",
+    "arguments": {
+        "channel": {
+            "name": "channel",
+            "description": "Channel to send welcomes"
+        },
+        "message": {
+            "name": "message",
+            "description": "Welcome text. Use {user} and {server}"
+        }
+    },
+    "success": "Welcome messages will be sent in {channel}"
+}


### PR DESCRIPTION
## Summary
- add a Welcome module with service to send custom welcome messages
- add command `setwelcome` for admins to configure channel and message
- add database model to store per-guild welcome settings
- include English translations

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'zumito-framework')*
- `npm install` *(fails: ENOTFOUND github.com)*

------
https://chatgpt.com/codex/tasks/task_e_684b02a1a100832f9114346a57b7ae36