### PR TITLE
Fix guild ID substitution in user panel nav

### DIFF
--- a/src/modules/userPanel/routes/UserPanel.ts
+++ b/src/modules/userPanel/routes/UserPanel.ts
@@ -66,7 +66,7 @@ export class UserPanel extends Route {
         const userPanelView = new UserPanelViewService();
         const html = await userPanelView.render({
             content,
-            reqPath: this.path,
+            reqPath: req.path,
             req, res,
             options: {
                 hideSidebar: true,

--- a/src/modules/userPanel/routes/UserPanelGuild.ts
+++ b/src/modules/userPanel/routes/UserPanelGuild.ts
@@ -59,7 +59,7 @@ export class UserPanelGuild extends Route {
         const userPanelView = new UserPanelViewService();
         const html = await userPanelView.render({
             content,
-            reqPath: this.path,
+            reqPath: req.path,
             req, res,
         });
         res.send(html);

--- a/src/modules/userPanel/services/UserPanelNavigationService.ts
+++ b/src/modules/userPanel/services/UserPanelNavigationService.ts
@@ -27,4 +27,26 @@ export class UserPanelNavigationService {
     getItems() {
         return this.items;
     }
+
+    /**
+     * Returns a copy of the navigation items replacing the `:guildId` token
+     * with the provided guild id on every url, including sidebar links.
+     */
+    getItemsWithGuildId(guildId: string): NavItem[] {
+        const replaceId = (url: string) => url.replace(/:guildId(?:\(.*?\))?/, guildId);
+        return this.items.map(item => ({
+            ...item,
+            url: replaceId(item.url),
+            sidebar: item.sidebar ? {
+                ...item.sidebar,
+                sections: item.sidebar.sections.map(section => ({
+                    ...section,
+                    items: section.items.map(child => ({
+                        ...child,
+                        url: replaceId(child.url),
+                    })),
+                })),
+            } : undefined,
+        }));
+    }
 }

--- a/src/modules/userPanel/services/UserPanelViewService.ts
+++ b/src/modules/userPanel/services/UserPanelViewService.ts
@@ -32,7 +32,15 @@ export class UserPanelViewService {
             hideSidebar?: boolean,
         }
     }) {
-        const navItems = this.navigationService.getItems();
+        const guildId = req.params?.guildId;
+        const navItems = guildId
+            ? this.navigationService.getItemsWithGuildId(guildId)
+            : this.navigationService.getItems();
+
+        if (guildId) {
+            reqPath = reqPath.replace(/:guildId(?:\(.*?\))?/, guildId);
+        }
+
         let selectedNavItem = navItems.find(item => item.url === reqPath);
         if (!selectedNavItem) {
             selectedNavItem = navItems.find(item =>

--- a/src/modules/welcome/routes/UserPanelWelcome.ts
+++ b/src/modules/welcome/routes/UserPanelWelcome.ts
@@ -46,7 +46,7 @@ export class UserPanelWelcome extends Route {
             { guild, config, channels }
         );
         const view = new UserPanelViewService();
-        const html = await view.render({ content, reqPath: this.path, req, res });
+        const html = await view.render({ content, reqPath: req.path, req, res });
         res.send(html);
     }
 }


### PR DESCRIPTION
## Summary
- replace `:guildId` placeholder with guild id in `UserPanelNavigationService`
- adjust `UserPanelViewService` to use updated URLs and selected path
- pass `req.path` when rendering UserPanel views

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684b369fe47c832fbe88e77f4b66ce8c