### PR TITLE
Add animated stickmanfight command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@distube/youtube": "^1.0.4",
         "@distube/yt-dlp": "^2.0.1",
         "@distube/ytdl-core": "^4.16.11",
+        "canvas": "^2.11.2",
         "discord.js": "^14.14.1",
         "distube": "^5.0.7",
         "dotenv": "^16.0.3",
@@ -24,6 +25,7 @@
         "express": "^5.1.0",
         "ffmpeg-static": "^5.1.0",
         "fs-readdir-recursive": "^1.1.0",
+        "gifencoder": "^2.0.1",
         "jose": "^6.0.11",
         "sodium-native": "^4.3.1",
         "zumito-framework": "^1.6.4"
@@ -46,7 +48,7 @@
         "vite": "^6.3.5"
       },
       "engines": {
-        "node": ">=18.0.0",
+        "node": ">=20.0.0",
         "npm": ">=8.0.0"
       }
     },
@@ -1497,6 +1499,26 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.11.tgz",
+      "integrity": "sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "make-dir": "^3.1.0",
+        "node-fetch": "^2.6.7",
+        "nopt": "^5.0.0",
+        "npmlog": "^5.0.1",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.5",
+        "tar": "^6.1.11"
+      },
+      "bin": {
+        "node-pre-gyp": "bin/node-pre-gyp"
       }
     },
     "node_modules/@mongodb-js/saslprep": {
@@ -3147,6 +3169,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/canvas": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.11.2.tgz",
+      "integrity": "sha512-ItanGBMrmRV7Py2Z+Xhs7cT+FNt5K0vPL4p9EZ/UX/Mu7hFbkxSjKF2KVtPwX7UYWp7dRKnrTvReflgrItJbdw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@mapbox/node-pre-gyp": "^1.0.0",
+        "nan": "^2.17.0",
+        "simple-get": "^3.0.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
@@ -3441,6 +3478,18 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
+      "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/deep-is": {
@@ -4514,6 +4563,15 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/gifencoder": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/gifencoder/-/gifencoder-2.0.1.tgz",
+      "integrity": "sha512-x19DcyWY10SkshBpokqFOo/HBht9GB75evRYvaLMbez9p+yB/o+kt0fK9AwW59nFiAMs2UUQsjv1lX/hvu9Ong==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "canvas": "^2.2.0"
+      }
+    },
     "node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -5277,6 +5335,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
+      "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/miniget": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/miniget/-/miniget-4.2.3.tgz",
@@ -5448,6 +5518,12 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
+    },
+    "node_modules/nan": {
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.22.2.tgz",
+      "integrity": "sha512-DANghxFkS1plDdRsX0X9pm0Z6SJNN6gBdtXfanwoZ8hooC5gosGFSBGRYHUVPz1asKA/kMRqDRdHrluZ61SpBQ==",
+      "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -6337,6 +6413,37 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.1.tgz",
+      "integrity": "sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==",
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^4.2.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
     },
     "node_modules/slash": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@distube/youtube": "^1.0.4",
     "@distube/yt-dlp": "^2.0.1",
     "@distube/ytdl-core": "^4.16.11",
+    "canvas": "^2.11.2",
     "discord.js": "^14.14.1",
     "distube": "^5.0.7",
     "dotenv": "^16.0.3",
@@ -36,6 +37,7 @@
     "express": "^5.1.0",
     "ffmpeg-static": "^5.1.0",
     "fs-readdir-recursive": "^1.1.0",
+    "gifencoder": "^2.0.1",
     "jose": "^6.0.11",
     "sodium-native": "^4.3.1",
     "zumito-framework": "^1.6.4"

--- a/src/modules/fun/commands/stickmanfight.ts
+++ b/src/modules/fun/commands/stickmanfight.ts
@@ -1,0 +1,129 @@
+import { Command, CommandParameters, CommandType, CommandArgDefinition } from 'zumito-framework';
+import { AttachmentBuilder, EmbedBuilder, GuildMember, User } from 'zumito-framework/discord';
+import { config } from '../../config/index.js';
+
+export class Stickmanfight extends Command {
+    type = CommandType.any;
+    args: CommandArgDefinition[] = [
+        { name: 'user1', type: 'user', optional: true },
+        { name: 'user2', type: 'user', optional: true },
+    ];
+
+    async execute({ message, interaction, args, trans }: CommandParameters): Promise<void> {
+        const guild = message?.guild || interaction?.guild;
+        if (!guild) return;
+        const members = guild.members.cache.filter(m => !m.user.bot).map(m => m as GuildMember);
+        if (members.length < 2) {
+            (message || interaction!)?.reply({ content: 'Not enough members', ephemeral: true });
+            return;
+        }
+        const first = args.get('user1') as User | undefined;
+        const second = args.get('user2') as User | undefined;
+
+        const getRandomMember = (excludeId?: string): GuildMember => {
+            const filtered = excludeId ? members.filter(m => m.id !== excludeId) : members;
+            return filtered[Math.floor(Math.random() * filtered.length)];
+        };
+
+        const firstMember = first ? (guild.members.cache.get(first.id) as GuildMember) : getRandomMember();
+        const secondMember = second ? (guild.members.cache.get(second.id) as GuildMember) : getRandomMember(firstMember.id);
+
+        const { createCanvas, loadImage } = await import('canvas');
+        const GIF = await import('gifencoder');
+        const GIFEncoder = (GIF as any).default || (GIF as any);
+        const width = 400;
+        const height = 200;
+        const encoder = new GIFEncoder(width, height);
+        encoder.start();
+        encoder.setRepeat(0);
+        encoder.setDelay(200);
+        encoder.setQuality(10);
+
+        const canvas = createCanvas(width, height);
+        const ctx = canvas.getContext('2d');
+
+        const avatar1 = await loadImage(firstMember.user.displayAvatarURL({ extension: 'png', size: 64 }));
+        const avatar2 = await loadImage(secondMember.user.displayAvatarURL({ extension: 'png', size: 64 }));
+
+        const drawStickman = (x: number, y: number, avatar: any, lying = false) => {
+            ctx.strokeStyle = '#000';
+            ctx.lineWidth = 3;
+            ctx.save();
+            ctx.beginPath();
+            ctx.arc(x, y, 15, 0, Math.PI * 2);
+            ctx.closePath();
+            ctx.clip();
+            ctx.drawImage(avatar, x - 15, y - 15, 30, 30);
+            ctx.restore();
+
+            if (lying) {
+                ctx.beginPath();
+                ctx.moveTo(x - 20, y + 15);
+                ctx.lineTo(x + 20, y + 15);
+                ctx.stroke();
+                return;
+            }
+
+            ctx.beginPath();
+            ctx.moveTo(x, y + 15);
+            ctx.lineTo(x, y + 55);
+            ctx.moveTo(x, y + 25);
+            ctx.lineTo(x - 15, y + 40);
+            ctx.moveTo(x, y + 25);
+            ctx.lineTo(x + 15, y + 40);
+            ctx.moveTo(x, y + 55);
+            ctx.lineTo(x - 15, y + 80);
+            ctx.moveTo(x, y + 55);
+            ctx.lineTo(x + 15, y + 80);
+            ctx.stroke();
+        };
+
+        const winner = Math.random() < 0.5 ? 'first' : 'second';
+
+        for (let i = 0; i < 6; i++) {
+            ctx.fillStyle = '#fff';
+            ctx.fillRect(0, 0, width, height);
+            const x1 = 60 + i * 25;
+            const x2 = 340 - i * 25;
+            drawStickman(x1, 50, avatar1);
+            drawStickman(x2, 50, avatar2);
+            if (i === 2) {
+                ctx.fillStyle = '#ff0000';
+                ctx.font = '20px sans-serif';
+                ctx.fillText('VS', 190, 90);
+            }
+            encoder.addFrame(ctx);
+        }
+
+        ctx.fillStyle = '#fff';
+        ctx.fillRect(0, 0, width, height);
+        if (winner === 'first') {
+            drawStickman(180, 50, avatar1);
+            drawStickman(220, 50, avatar2, true);
+        } else {
+            drawStickman(180, 50, avatar1, true);
+            drawStickman(220, 50, avatar2);
+        }
+        ctx.fillStyle = '#ff0000';
+        ctx.font = '20px sans-serif';
+        ctx.fillText('KO!', 190, 90);
+        encoder.addFrame(ctx);
+
+        encoder.finish();
+        const buffer = Buffer.from(encoder.out.getData());
+        const attachment = new AttachmentBuilder(buffer, { name: 'stickmanfight.gif' });
+
+        const embed = new EmbedBuilder()
+            .setDescription(trans('result', {
+                user1: firstMember.user.globalName || firstMember.user.username,
+                user2: secondMember.user.globalName || secondMember.user.username,
+                winner: winner === 'first'
+                    ? (firstMember.user.globalName || firstMember.user.username)
+                    : (secondMember.user.globalName || secondMember.user.username),
+            }))
+            .setColor(config.colors.default)
+            .setImage('attachment://stickmanfight.gif');
+
+        (message || interaction!)?.reply({ embeds: [embed], files: [attachment] });
+    }
+}

--- a/src/modules/fun/translations/stickmanfight/en.json
+++ b/src/modules/fun/translations/stickmanfight/en.json
@@ -1,0 +1,4 @@
+{
+  "description": "Start an animated stickman fight between two users.",
+  "result": "{user1} vs {user2}! Winner: {winner}"
+}

--- a/src/modules/fun/translations/stickmanfight/es.json
+++ b/src/modules/fun/translations/stickmanfight/es.json
@@ -1,0 +1,4 @@
+{
+  "description": "Inicia una pelea animada de stickmans entre dos usuarios.",
+  "result": "{user1} vs {user2}! Gana {winner}"
+}


### PR DESCRIPTION
## Summary
- include gifencoder dependency
- implement an animated `stickmanfight` command that uses user avatars as heads
- update English and Spanish translations

## Testing
- `npm install --package-lock-only`


------
https://chatgpt.com/codex/tasks/task_e_684b345a5f80832f9fab4bbd3e281027