### PR TITLE
Implement XP gain per message

### DIFF
--- a/src/modules/ranks/index.ts
+++ b/src/modules/ranks/index.ts
@@ -1,5 +1,6 @@
 import { Module, ServiceContainer, ZumitoFramework } from "zumito-framework";
 import { RankService } from "./services/RankService";
+import { RankMessageService } from "./services/RankMessageService";
 import { RankCommand } from "./commands/rank";
 import { LeaderboardCommand } from "./commands/leaderboard";
 
@@ -7,5 +8,6 @@ export class RanksModule extends Module {
     constructor(modulePath: string, framework: ZumitoFramework) {
         super(modulePath);
         ServiceContainer.addService(RankService, [], true);
+        ServiceContainer.addService(RankMessageService, [], true);
     }
 }

--- a/src/modules/ranks/services/RankMessageService.ts
+++ b/src/modules/ranks/services/RankMessageService.ts
@@ -1,0 +1,21 @@
+import { Client } from 'zumito-framework/discord';
+import { ServiceContainer } from 'zumito-framework';
+import { RankService } from './RankService';
+
+export class RankMessageService {
+    private client: Client;
+    private rankService: RankService;
+
+    constructor() {
+        this.client = ServiceContainer.getService(Client);
+        this.rankService = ServiceContainer.getService(RankService);
+        this.registerEvents();
+    }
+
+    private registerEvents() {
+        this.client.on('messageCreate', async (message) => {
+            if (message.author.bot || !message.guild) return;
+            await this.rankService.addXp(message.guild.id, message.author.id, 1);
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- create `RankMessageService` to listen to `messageCreate` and award XP via `RankService`
- register `RankMessageService` within `RanksModule`

## Testing
- `npx eslint .` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*

------
https://chatgpt.com/codex/tasks/task_e_684bccb496c8832f8266abf6b02c007f