### PR TITLE
Fix __dirname for economy admin route

### DIFF
--- a/src/modules/economy/routes/AdminEconomy.ts
+++ b/src/modules/economy/routes/AdminEconomy.ts
@@ -3,8 +3,11 @@ import { AdminAuthService } from '../../admin/services/AdminAuthService';
 import { AdminViewService } from '../../admin/services/AdminViewService';
 import { EconomyService } from '../services/EconomyService';
 import { Client } from 'zumito-framework/discord';
-import path from 'path';
+import path, { dirname } from 'path';
+import { fileURLToPath } from 'url';
 import ejs from 'ejs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 export class AdminEconomy extends Route {
     method = RouteMethod.get;


### PR DESCRIPTION
## Summary
- ensure `__dirname` is defined in AdminEconomy route

## Testing
- `npm ci` *(fails: connect ENETUNREACH)*
- `npx eslint .` *(fails: cannot find module '@typescript-eslint/eslint-plugin')*

------
https://chatgpt.com/codex/tasks/task_e_684be572e120832f9f237d6551c54ecb