### PR TITLE
Add server landing pages module

### DIFF
--- a/src/modules/serverPages/index.ts
+++ b/src/modules/serverPages/index.ts
@@ -1,0 +1,9 @@
+import { Module, ServiceContainer, ZumitoFramework } from "zumito-framework";
+import { ServerPageViewService } from "./services/ServerPageViewService";
+
+export class ServerPagesModule extends Module {
+    constructor(modulePath: string, framework: ZumitoFramework) {
+        super(modulePath);
+        ServiceContainer.addService(ServerPageViewService, [], true);
+    }
+}

--- a/src/modules/serverPages/routes/ServerLanding.ts
+++ b/src/modules/serverPages/routes/ServerLanding.ts
@@ -1,0 +1,37 @@
+import { Route, RouteMethod, ServiceContainer } from "zumito-framework";
+import { Client } from "zumito-framework/discord";
+import { ServerPageViewService } from "../services/ServerPageViewService";
+import ejs from "ejs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export class ServerLanding extends Route {
+    method = RouteMethod.get;
+    path = '/server/:guildId';
+
+    constructor(private client: Client = ServiceContainer.getService(Client)) {
+        super();
+    }
+
+    async execute(req: any, res: any) {
+        const guildId = req.params.guildId as string;
+        const guild = this.client.guilds.cache.get(guildId);
+        if (!guild) return res.status(404).send('Servidor no encontrado');
+
+        const tagline = process.env.SERVER_LANDING_TAGLINE || 'Bienvenido a nuestro servidor!';
+        const inviteUrl = process.env.SERVER_LANDING_INVITE || guild.vanityURLCode ? `https://discord.gg/${guild.vanityURLCode}` : `https://discord.com/oauth2/authorize?client_id=${this.client.user?.id}&scope=bot+applications.commands&guild_id=${guildId}`;
+
+        const theme = ServerPageViewService.getTheme();
+
+        const content = await ejs.renderFile(
+            path.join(__dirname, '../views/server-landing.ejs'),
+            { guild, tagline, inviteUrl, theme }
+        );
+
+        const view = new ServerPageViewService();
+        const html = await view.render({ title: guild.name, content, extra: { theme } });
+        res.send(html);
+    }
+}

--- a/src/modules/serverPages/services/ServerPageViewService.ts
+++ b/src/modules/serverPages/services/ServerPageViewService.ts
@@ -1,0 +1,35 @@
+import ejs from "ejs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+export class ServerPageViewService {
+    private static layoutPath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../views/layouts/server-landing.ejs');
+
+    async render({
+        title,
+        content,
+        extra = {}
+    }: {
+        title: string;
+        content: string;
+        extra?: Record<string, any>;
+    }): Promise<string> {
+        return await ejs.renderFile(
+            ServerPageViewService.layoutPath,
+            {
+                title,
+                content,
+                ...extra,
+                theme: (extra && extra.theme) || ServerPageViewService.getTheme()
+            }
+        );
+    }
+
+    static getTheme() {
+        return {
+            primary: process.env.SERVER_LANDING_COLOR_PRIMARY || '#5865F2',
+            secondary: process.env.SERVER_LANDING_COLOR_SECONDARY || '#36393f',
+            accent: process.env.SERVER_LANDING_COLOR_ACCENT || '#57F287'
+        };
+    }
+}

--- a/src/modules/serverPages/views/layouts/server-landing.ejs
+++ b/src/modules/serverPages/views/layouts/server-landing.ejs
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title><%= title %></title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <style>
+        :root {
+            --primary: <%= theme.primary %>;
+            --secondary: <%= theme.secondary %>;
+            --accent: <%= theme.accent %>;
+        }
+        body {
+            background: linear-gradient(135deg, var(--primary) 0%, var(--secondary) 60%, var(--accent) 100%);
+        }
+    </style>
+</head>
+<body class="min-h-screen flex flex-col">
+    <%- content %>
+</body>
+</html>

--- a/src/modules/serverPages/views/server-landing.ejs
+++ b/src/modules/serverPages/views/server-landing.ejs
@@ -1,0 +1,10 @@
+<main class="flex flex-col items-center justify-center flex-1 p-8 text-center">
+    <% if (guild.iconURL()) { %>
+        <img src="<%= guild.iconURL() %>" alt="<%= guild.name %>" class="w-32 h-32 rounded-full shadow-lg mb-4">
+    <% } %>
+    <h1 class="text-4xl font-bold text-white mb-2"><%= guild.name %></h1>
+    <p class="text-white/80 mb-6"><%= tagline %></p>
+    <a href="<%= inviteUrl %>" class="px-6 py-3 rounded-md text-white font-medium" style="background: <%= theme.primary %>;">
+        Unirse al servidor
+    </a>
+</main>


### PR DESCRIPTION
## Summary
- create new `serverPages` module to host guild landing pages
- provide a layout service so other modules can add pages
- add route for `/server/:guildId` basic landing

## Testing
- `npx eslint .` *(fails: cannot find module '@typescript-eslint/eslint-plugin')*

------
https://chatgpt.com/codex/tasks/task_e_684be9c346fc832fbded1e79b5bf752b