### PR TITLE
Fix server checks in user panel

### DIFF
--- a/src/modules/userPanel/routes/UserPanelGuild.ts
+++ b/src/modules/userPanel/routes/UserPanelGuild.ts
@@ -30,7 +30,10 @@ export class UserPanelGuild extends Route {
         const client = this.client;
         const guild = client.guilds.cache.get(guildId);
         if (!guild) return res.status(404).send('Servidor no encontrado');
-        const member = guild.members.cache.get(userId);
+        let member = guild.members.cache.get(userId);
+        if (!member) {
+            member = await guild.members.fetch(userId).catch(() => null);
+        }
         if (!member || !(member.permissions.has(PermissionFlagsBits.Administrator) || member.permissions.has(PermissionFlagsBits.ManageGuild) || guild.ownerId === userId)) {
             console.log('Member:', member);
             console.log('Member Admin Permissions:', member?.permissions.has(PermissionFlagsBits.Administrator));

--- a/src/modules/welcome/routes/UserPanelWelcome.ts
+++ b/src/modules/welcome/routes/UserPanelWelcome.ts
@@ -30,7 +30,10 @@ export class UserPanelWelcome extends Route {
         const guildId = req.params.guildId;
         const guild = this.client.guilds.cache.get(guildId);
         if (!guild) return res.status(404).send('Servidor no encontrado');
-        const member = guild.members.cache.get(userId);
+        let member = guild.members.cache.get(userId);
+        if (!member) {
+            member = await guild.members.fetch(userId).catch(() => null);
+        }
         if (!member || !(member.permissions.has(PermissionFlagsBits.Administrator) || member.permissions.has(PermissionFlagsBits.ManageGuild) || guild.ownerId === userId)) {
             return res.status(403).send('No tienes permisos en este servidor');
         }

--- a/src/modules/welcome/routes/UserPanelWelcomePost.ts
+++ b/src/modules/welcome/routes/UserPanelWelcomePost.ts
@@ -22,7 +22,10 @@ export class UserPanelWelcomePost extends Route {
         const guildId = req.params.guildId;
         const guild = this.client.guilds.cache.get(guildId);
         if (!guild) return res.status(404).send('Servidor no encontrado');
-        const member = guild.members.cache.get(userId);
+        let member = guild.members.cache.get(userId);
+        if (!member) {
+            member = await guild.members.fetch(userId).catch(() => null);
+        }
         if (!member || !(member.permissions.has(PermissionFlagsBits.Administrator) || member.permissions.has(PermissionFlagsBits.ManageGuild) || guild.ownerId === userId)) {
             return res.status(403).send('No tienes permisos en este servidor');
         }


### PR DESCRIPTION
## Summary
- fetch guild member from API if not cached when checking admin rights
- apply same fix to welcome module routes

## Testing
- `npx eslint .` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*
- `npm install` *(fails: connect ENETUNREACH 140.82.112.4:443)*

------
https://chatgpt.com/codex/tasks/task_e_684be9df0b90832f8ca7c2ddc3ad3a5d