### PR TITLE
Add Valorant module with agent and weapon commands

### DIFF
--- a/src/modules/valorant/commands/agent.ts
+++ b/src/modules/valorant/commands/agent.ts
@@ -1,0 +1,50 @@
+import { EmbedBuilder } from "zumito-framework/discord";
+import { Command, CommandArgDefinition, CommandParameters, CommandType } from "zumito-framework";
+import { config } from "../../../config/index.js";
+
+export class ValorantAgentCommand extends Command {
+    name = "valorantagent";
+    description = "Show information about a Valorant agent.";
+    categories = ["valorant"];
+    args: CommandArgDefinition[] = [
+        { name: "agent", type: "string", optional: false }
+    ];
+    botPermissions = ["VIEW_CHANNEL", "SEND_MESSAGES", "EMBED_LINKS"];
+    type = CommandType.any;
+
+    async execute({ message, interaction, args, trans }: CommandParameters): Promise<void> {
+        const agentName = args.get("agent");
+        if (!agentName) {
+            (message || interaction)?.reply({
+                content: trans('error'),
+                allowedMentions: { repliedUser: false }
+            });
+            return;
+        }
+        try {
+            const res = await fetch("https://valorant-api.com/v1/agents?isPlayableCharacter=true&language=en-US");
+            const json = await res.json();
+            const agent = json.data.find((a: any) => a.displayName.toLowerCase() === agentName.toLowerCase());
+            if (!agent) {
+                (message || interaction)?.reply({
+                    content: trans('notfound', { agent: agentName }),
+                    allowedMentions: { repliedUser: false }
+                });
+                return;
+            }
+            const embed = new EmbedBuilder()
+                .setTitle(agent.displayName)
+                .setDescription(agent.description)
+                .setThumbnail(agent.displayIcon)
+                .setImage(agent.fullPortrait)
+                .addFields({ name: trans('role'), value: agent.role?.displayName || trans('unknown') })
+                .setColor(config.colors.default);
+            (message || interaction)?.reply({ embeds: [embed], allowedMentions: { repliedUser: false } });
+        } catch {
+            (message || interaction)?.reply({
+                content: trans('fail'),
+                allowedMentions: { repliedUser: false }
+            });
+        }
+    }
+}

--- a/src/modules/valorant/commands/weapon.ts
+++ b/src/modules/valorant/commands/weapon.ts
@@ -1,0 +1,51 @@
+import { EmbedBuilder } from "zumito-framework/discord";
+import { Command, CommandArgDefinition, CommandParameters, CommandType } from "zumito-framework";
+import { config } from "../../../config/index.js";
+
+export class ValorantWeaponCommand extends Command {
+    name = "valorantweapon";
+    description = "Show information about a Valorant weapon.";
+    categories = ["valorant"];
+    args: CommandArgDefinition[] = [
+        { name: "weapon", type: "string", optional: false }
+    ];
+    botPermissions = ["VIEW_CHANNEL", "SEND_MESSAGES", "EMBED_LINKS"];
+    type = CommandType.any;
+
+    async execute({ message, interaction, args, trans }: CommandParameters): Promise<void> {
+        const weaponName = args.get("weapon");
+        if (!weaponName) {
+            (message || interaction)?.reply({
+                content: trans('error'),
+                allowedMentions: { repliedUser: false }
+            });
+            return;
+        }
+        try {
+            const res = await fetch("https://valorant-api.com/v1/weapons");
+            const json = await res.json();
+            const weapon = json.data.find((w: any) => w.displayName.toLowerCase() === weaponName.toLowerCase());
+            if (!weapon) {
+                (message || interaction)?.reply({
+                    content: trans('notfound', { weapon: weaponName }),
+                    allowedMentions: { repliedUser: false }
+                });
+                return;
+            }
+            const embed = new EmbedBuilder()
+                .setTitle(weapon.displayName)
+                .setThumbnail(weapon.displayIcon)
+                .addFields(
+                    { name: trans('category'), value: weapon.shopData?.categoryText || trans('unknown') },
+                    { name: trans('cost'), value: weapon.shopData?.cost ? weapon.shopData.cost.toString() : '0' }
+                )
+                .setColor(config.colors.default);
+            (message || interaction)?.reply({ embeds: [embed], allowedMentions: { repliedUser: false } });
+        } catch {
+            (message || interaction)?.reply({
+                content: trans('fail'),
+                allowedMentions: { repliedUser: false }
+            });
+        }
+    }
+}

--- a/src/modules/valorant/index.ts
+++ b/src/modules/valorant/index.ts
@@ -1,0 +1,7 @@
+import { Module, ZumitoFramework } from "zumito-framework";
+
+export class ValorantModule extends Module {
+    constructor(modulePath: string, framework: ZumitoFramework) {
+        super(modulePath);
+    }
+}

--- a/src/modules/valorant/translations/command/agent/en.json
+++ b/src/modules/valorant/translations/command/agent/en.json
@@ -1,0 +1,13 @@
+{
+    "description": "Show information about a Valorant agent.",
+    "role": "Role",
+    "unknown": "Unknown",
+    "fail": "Could not retrieve agent information.",
+    "notfound": "Agent {agent} not found.",
+    "arguments": {
+        "agent": { "name": "agent" }
+    },
+    "args": {
+        "agent": { "description": "Agent name" }
+    }
+}

--- a/src/modules/valorant/translations/command/agent/es.json
+++ b/src/modules/valorant/translations/command/agent/es.json
@@ -1,0 +1,13 @@
+{
+    "description": "Muestra información sobre un agente de Valorant.",
+    "role": "Rol",
+    "unknown": "Desconocido",
+    "fail": "No se pudo obtener la información del agente.",
+    "notfound": "Agente {agent} no encontrado.",
+    "arguments": {
+        "agent": { "name": "agente" }
+    },
+    "args": {
+        "agent": { "description": "Nombre del agente" }
+    }
+}

--- a/src/modules/valorant/translations/command/weapon/en.json
+++ b/src/modules/valorant/translations/command/weapon/en.json
@@ -1,0 +1,14 @@
+{
+    "description": "Show information about a Valorant weapon.",
+    "category": "Category",
+    "cost": "Cost",
+    "unknown": "Unknown",
+    "fail": "Could not retrieve weapon information.",
+    "notfound": "Weapon {weapon} not found.",
+    "arguments": {
+        "weapon": { "name": "weapon" }
+    },
+    "args": {
+        "weapon": { "description": "Weapon name" }
+    }
+}

--- a/src/modules/valorant/translations/command/weapon/es.json
+++ b/src/modules/valorant/translations/command/weapon/es.json
@@ -1,0 +1,14 @@
+{
+    "description": "Muestra información sobre un arma de Valorant.",
+    "category": "Categoría",
+    "cost": "Costo",
+    "unknown": "Desconocido",
+    "fail": "No se pudo obtener la información del arma.",
+    "notfound": "Arma {weapon} no encontrada.",
+    "arguments": {
+        "weapon": { "name": "arma" }
+    },
+    "args": {
+        "weapon": { "description": "Nombre del arma" }
+    }
+}


### PR DESCRIPTION
## Summary
- add Valorant module scaffolding
- add `valorantagent` command to fetch agent information from valorant-api.com
- add `valorantweapon` command to show weapon details
- provide English and Spanish translations for the new commands

## Testing
- `npm install --ignore-scripts`
- `npx eslint .` *(fails: many errors in repo)*

------
https://chatgpt.com/codex/tasks/task_e_684bfbcf160c832f95a052eaee528711