### PR TITLE
Add mcuuid command

### DIFF
--- a/src/modules/global/translations/en.json
+++ b/src/modules/global/translations/en.json
@@ -68,6 +68,11 @@
                 "description": "Utility and tools commands",
                 "emoji": "🛠️"
             },
+            "minecraft": {
+                "name": "Minecraft",
+                "description": "Minecraft related commands",
+                "emoji": "⛏️"
+            },
             "reputation": {
                 "name": "Reputation",
                 "description": "Reputation system commands",

--- a/src/modules/global/translations/es.json
+++ b/src/modules/global/translations/es.json
@@ -68,6 +68,11 @@
                 "description": "Comandos de utilidades y herramientas",
                 "emoji": "🛠️"
             },
+            "minecraft": {
+                "name": "Minecraft",
+                "description": "Comandos relacionados con Minecraft",
+                "emoji": "⛏️"
+            },
             "reputation": {
                 "name": "Reputación",
                 "description": "Comandos de reputación",

--- a/src/modules/minecraft/commands/uuid.ts
+++ b/src/modules/minecraft/commands/uuid.ts
@@ -1,0 +1,43 @@
+import { EmbedBuilder } from "zumito-framework/discord";
+import { Command, CommandArgDefinition, CommandParameters } from "zumito-framework";
+import { ServiceContainer } from "zumito-framework";
+import { config } from "../../../config/index.js";
+import { HypixelService } from "../services/HypixelService.js";
+
+export class UUIDCommand extends Command {
+    name = "mcuuid";
+    description = "Shows the UUID of a Minecraft player";
+    categories = ["minecraft"];
+    args: CommandArgDefinition[] = [{
+        name: "username",
+        type: "string",
+        optional: false,
+    }];
+    botPermissions = ["VIEW_CHANNEL", "SEND_MESSAGES", "EMBED_LINKS"];
+
+    hypixel: HypixelService;
+
+    constructor() {
+        super();
+        this.hypixel = ServiceContainer.getService(HypixelService);
+    }
+
+    async execute({ message, interaction, args, trans }: CommandParameters): Promise<void> {
+        const username = args.get("username");
+        if (!username) {
+            (message || interaction)?.reply({ content: trans('error'), allowedMentions: { repliedUser: false } });
+            return;
+        }
+        const uuid = await this.hypixel.getUUID(username);
+        if (!uuid) {
+            (message || interaction)?.reply({ content: trans('notfound'), allowedMentions: { repliedUser: false } });
+            return;
+        }
+        const embed = new EmbedBuilder()
+            .setTitle(trans('title', { user: username }))
+            .setDescription(trans('uuid', { uuid }))
+            .setColor(config.colors.default);
+
+        (message || interaction)?.reply({ embeds: [embed], allowedMentions: { repliedUser: false } });
+    }
+}

--- a/src/modules/minecraft/translations/command/uuid/en.json
+++ b/src/modules/minecraft/translations/command/uuid/en.json
@@ -1,0 +1,13 @@
+{
+    "description": "Displays the UUID of a Minecraft player.",
+    "title": "UUID of {user}",
+    "uuid": "{uuid}",
+    "notfound": "Player not found.",
+    "error": "You must provide a Minecraft username.",
+    "arguments": {
+        "username": { "name": "username" }
+    },
+    "args": {
+        "username": { "description": "Player username" }
+    }
+}

--- a/src/modules/minecraft/translations/command/uuid/es.json
+++ b/src/modules/minecraft/translations/command/uuid/es.json
@@ -1,0 +1,13 @@
+{
+    "description": "Muestra el UUID de un jugador de Minecraft.",
+    "title": "UUID de {user}",
+    "uuid": "{uuid}",
+    "notfound": "Jugador no encontrado.",
+    "error": "Debes proporcionar un nombre de usuario de Minecraft.",
+    "arguments": {
+        "username": { "name": "usuario" }
+    },
+    "args": {
+        "username": { "description": "Nombre de usuario" }
+    }
+}


### PR DESCRIPTION
## Summary
- add `/mcuuid` command to show player UUID
- add translations for the new command
- register minecraft category in global translations

## Testing
- `npx eslint .` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*

------
https://chatgpt.com/codex/tasks/task_e_684bfca10ed0832fbedaeea065c50ab8