### PR TITLE
Add free TTS command

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "ffmpeg-static": "^5.1.0",
     "fs-readdir-recursive": "^1.1.0",
     "gifencoder": "^2.0.1",
+    "google-tts-api": "^2.0.2",
     "jose": "^6.0.11",
     "sodium-native": "^4.3.1",
     "zumito-db": "^1.0.1",

--- a/src/modules/utils/commands/tts.ts
+++ b/src/modules/utils/commands/tts.ts
@@ -1,0 +1,38 @@
+import { Command, CommandParameters } from "zumito-framework";
+import { AttachmentBuilder } from "discord.js";
+import googleTTS from "google-tts-api";
+
+export class TTSCommand extends Command {
+    name = "tts";
+    description = "Reproduce texto usando Google TTS.";
+    categories = ["utilities"];
+    usage = "tts <texto>";
+    args = [
+        { name: "texto", type: "string", optional: false }
+    ];
+
+    async execute({ message, interaction, args }: CommandParameters): Promise<void> {
+        const text = args.get("texto");
+        if (!text) {
+            const reply = "Debes proporcionar un texto.";
+            if (interaction) await interaction.reply({ content: reply, ephemeral: true });
+            if (message) await message.reply(reply);
+            return;
+        }
+        try {
+            const url = googleTTS.getAudioUrl(text, {
+                lang: "es",
+                slow: false,
+            });
+            const res = await fetch(url);
+            const buffer = Buffer.from(await res.arrayBuffer());
+            const attachment = new AttachmentBuilder(buffer, { name: "tts.mp3" });
+            if (interaction) await interaction.reply({ files: [attachment] });
+            if (message) await message.reply({ files: [attachment] });
+        } catch (e) {
+            const reply = `❌ Error generando audio: ${e}`;
+            if (interaction) await interaction.reply({ content: reply, ephemeral: true });
+            if (message) await message.reply(reply);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `google-tts-api` to dependencies
- create `tts` command that sends an MP3 audio generated with Google TTS

## Testing
- `npx eslint .` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*
- `npm install` *(fails: ENETUNREACH when downloading dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684c00881704832face93521560dc2ef