### PR TITLE
Add missing category translations

### DIFF
--- a/src/modules/global/translations/en.json
+++ b/src/modules/global/translations/en.json
@@ -77,6 +77,26 @@
                 "name": "Reputation",
                 "description": "Reputation system commands",
                 "emoji": "⭐"
+            },
+            "roblox": {
+                "name": "Roblox",
+                "description": "Roblox commands",
+                "emoji": "🧱"
+            },
+            "minigames": {
+                "name": "Minigames",
+                "description": "Minigames commands",
+                "emoji": "🎮"
+            },
+            "valorant": {
+                "name": "Valorant",
+                "description": "Valorant commands",
+                "emoji": "🔫"
+            },
+            "utils": {
+                "name": "Utils",
+                "description": "Utility commands",
+                "emoji": "📊"
             }
         },
         "requested": "Requested by {user}",

--- a/src/modules/global/translations/es.json
+++ b/src/modules/global/translations/es.json
@@ -77,6 +77,26 @@
                 "name": "Reputación",
                 "description": "Comandos de reputación",
                 "emoji": "⭐"
+            },
+            "roblox": {
+                "name": "Roblox",
+                "description": "Comandos de Roblox",
+                "emoji": "🧱"
+            },
+            "minigames": {
+                "name": "Minijuegos",
+                "description": "Comandos de minijuegos",
+                "emoji": "🎮"
+            },
+            "valorant": {
+                "name": "Valorant",
+                "description": "Comandos de Valorant",
+                "emoji": "🔫"
+            },
+            "utils": {
+                "name": "Utilidades",
+                "description": "Comandos de utilidades",
+                "emoji": "📊"
             }
         },
         "requested": "Pedido por {user}",


### PR DESCRIPTION
## Summary
- translate missing categories in English and Spanish

## Testing
- `npx eslint .` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*
- `npm ci` *(fails: ENETUNREACH to github.com)*

------
https://chatgpt.com/codex/tasks/task_e_684c01566e60832fae324d8d0210a337