### PR TITLE
Add Spanish translation for setwelcome command

### DIFF
--- a/src/modules/welcome/translations/command/setwelcome/es.json
+++ b/src/modules/welcome/translations/command/setwelcome/es.json
@@ -1,0 +1,14 @@
+{
+    "description": "Configura el canal y mensaje de bienvenida.",
+    "arguments": {
+        "channel": {
+            "name": "canal",
+            "description": "Canal para enviar las bienvenidas"
+        },
+        "message": {
+            "name": "mensaje",
+            "description": "Texto de bienvenida. Usa {user} y {server}"
+        }
+    },
+    "success": "Los mensajes de bienvenida se enviarán en {channel}"
+}


### PR DESCRIPTION
## Summary
- add missing `es.json` translation for the `setwelcome` command

## Testing
- `npx eslint .` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*

------
https://chatgpt.com/codex/tasks/task_e_684c0162b3a0832fab17863159a3ebd1