### PR TITLE
Fix tetris message edit

### DIFF
--- a/src/modules/minigames/commands/tetris.ts
+++ b/src/modules/minigames/commands/tetris.ts
@@ -140,11 +140,11 @@ export class TetrisCommand extends Command {
             height: 20,
         };
         spawnPiece(state);
+        const sent = message ? await message.reply(render(state)) : await interaction.reply({ ...render(state), fetchReply: true });
         state.interval = setInterval(async () => {
             step(state);
-            if (msg.edit) { await msg.edit(render(state)); }
+            await sent.edit(render(state));
         }, 1000);
-        const sent = message ? await message.reply(render(state)) : await interaction.reply({ ...render(state), fetchReply: true });
         games.set(sent.id, state);
     }
 


### PR DESCRIPTION
## Summary
- update Tetris game to edit the bot's own message

## Testing
- `npx eslint .` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*

------
https://chatgpt.com/codex/tasks/task_e_684c06adfb4c832faf86c2528a1fb3a7