### PR TITLE
Fix simp command localization and add user argument

### DIFF
--- a/src/modules/fun/commands/simp.ts
+++ b/src/modules/fun/commands/simp.ts
@@ -1,13 +1,17 @@
-import { Command, CommandParameters, CommandType } from 'zumito-framework';
-import { EmbedBuilder } from 'zumito-framework/discord';
+import { Command, CommandParameters, CommandType, CommandArgDefinition } from 'zumito-framework';
+import { EmbedBuilder, User } from 'zumito-framework/discord';
 import { config } from '../../../config/index.js';
 
 export class Simp extends Command {
     type = CommandType.any;
+    args: CommandArgDefinition[] = [
+        { name: 'user', type: 'user', optional: true },
+    ];
 
-    async execute({ message, interaction, guildSettings, trans }: CommandParameters): Promise<void> {
+    async execute({ message, interaction, args, guildSettings, trans }: CommandParameters): Promise<void> {
         const channel = message?.channel || interaction?.channel;
-        const authorId = message?.author?.id || interaction?.user?.id;
+        const target = args.get('user') as User | undefined;
+        const authorId = target?.id || message?.author?.id || interaction?.user?.id;
 
         if (!channel || !('messages' in channel) || !authorId) return;
 

--- a/src/modules/fun/translations/command/simp/en.json
+++ b/src/modules/fun/translations/command/simp/en.json
@@ -1,0 +1,5 @@
+{
+  "description": "Find out who a user simps for based on their recent messages. If no user is specified, you will be checked.",
+  "result": "You seem to simp for {user}!",
+  "none": "I couldn't figure out who you simp for."
+}

--- a/src/modules/fun/translations/command/simp/es.json
+++ b/src/modules/fun/translations/command/simp/es.json
@@ -1,0 +1,5 @@
+{
+  "description": "Averigua a quién simpea un usuario según sus mensajes recientes. Si no se indica usuario, se usa el tuyo.",
+  "result": "¡Parece que simpeas a {user}!",
+  "none": "No pude detectar a quién simpeas."
+}

--- a/src/modules/fun/translations/simp/en.json
+++ b/src/modules/fun/translations/simp/en.json
@@ -1,5 +1,0 @@
-{
-  "description": "Find out who you simp for according to your recent messages.",
-  "result": "You seem to simp for {user}!",
-  "none": "I couldn't figure out who you simp for."
-}

--- a/src/modules/fun/translations/simp/es.json
+++ b/src/modules/fun/translations/simp/es.json
@@ -1,5 +1,0 @@
-{
-  "description": "Te dice a quién simpeas según tus mensajes recientes.",
-  "result": "¡Parece que simpeas a {user}!",
-  "none": "No pude detectar a quién simpeas."
-}


### PR DESCRIPTION
## Summary
- move simp command translations to `translations/command`
- allow passing a user to the simp command
- update translation strings describing optional user parameter

## Testing
- `npx eslint .` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*

------
https://chatgpt.com/codex/tasks/task_e_684c0d6e661c832facca0dff707e5579