### PR TITLE
Add Ticket Panel management

### DIFF
--- a/src/modules/tickets/services/TicketPanelService.ts
+++ b/src/modules/tickets/services/TicketPanelService.ts
@@ -1,0 +1,52 @@
+import { EmbedBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle, TextChannel, Client, PermissionFlagsBits } from 'discord.js';
+import { ServiceContainer, ZumitoFramework } from 'zumito-framework';
+
+export class TicketPanelService {
+    private framework: ZumitoFramework;
+    private client: Client;
+
+    constructor() {
+        this.framework = ServiceContainer.getService(ZumitoFramework);
+        this.client = ServiceContainer.getService(Client);
+    }
+
+    async createTicketPanel(guildId: string, data: any) {
+        const panel = { guildId, ...data };
+        const result = await this.framework.database.collection('ticket_panels').insertOne(panel);
+        return { ...panel, _id: result.insertedId };
+    }
+
+    async getTicketPanels(guildId: string) {
+        return await this.framework.database.collection('ticket_panels').find({ guildId }).toArray();
+    }
+
+    async getTicketPanel(panelId: string) {
+        const { ObjectId } = await import('mongodb');
+        return await this.framework.database.collection('ticket_panels').findOne({ _id: new ObjectId(panelId) });
+    }
+
+    async updateTicketPanel(panelId: string, data: any) {
+        const { ObjectId } = await import('mongodb');
+        await this.framework.database.collection('ticket_panels').updateOne({ _id: new ObjectId(panelId) }, { $set: data });
+        return this.getTicketPanel(panelId);
+    }
+
+    async deleteTicketPanel(panelId: string) {
+        const { ObjectId } = await import('mongodb');
+        await this.framework.database.collection('ticket_panels').deleteOne({ _id: new ObjectId(panelId) });
+    }
+
+    async sendTicketPanel(panelId: string, channelId: string) {
+        const panel = await this.getTicketPanel(panelId);
+        if (!panel) throw new Error('Panel not found');
+        const channel = await this.client.channels.fetch(channelId);
+        if (!channel || channel.type !== 0) throw new Error('Invalid channel');
+        const embed = EmbedBuilder.from(panel.embed || {});
+        const button = new ButtonBuilder()
+            .setCustomId(`ticket.open:${panelId}`)
+            .setLabel(panel.button?.label || 'Open Ticket')
+            .setStyle(ButtonStyle.Primary);
+        const row = new ActionRowBuilder<ButtonBuilder>().addComponents(button);
+        await (channel as TextChannel).send({ embeds: [embed], components: [row] });
+    }
+}

--- a/src/modules/tickets/services/TicketPanelService.ts
+++ b/src/modules/tickets/services/TicketPanelService.ts
@@ -41,6 +41,8 @@ export class TicketPanelService {
         if (!panel) throw new Error('Panel not found');
         const channel = await this.client.channels.fetch(channelId);
         if (!channel || channel.type !== 0) throw new Error('Invalid channel');
+        // convert color to int
+        panel.embed.color = parseInt(panel.embed.color.replace('#', ''), 16) || 0x5865F2; // Default to primary color if not set
         const embed = EmbedBuilder.from(panel.embed || {});
         const button = new ButtonBuilder()
             .setCustomId(`ticket.open:${panelId}`)

--- a/src/modules/userPanel/index.ts
+++ b/src/modules/userPanel/index.ts
@@ -51,5 +51,27 @@ export class UserPanelModule extends Module {
                 ],
             },
         });
+        navigationService.registerItem({
+            id: 'tickets',
+            icon: `<svg class="w-6 h-6 text-discord-white/60 group-hover:text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a2 2 0 10-2-2V7a2 2 0 10-2-2 2 2 0 100 4h-2a2 2 0 100 4v3.159c0 .538-.214 1.055-.595 1.436L10 17h5z" /></svg>`,
+            label: 'Tickets',
+            url: '/panel/:guildId(\\d+)/ticket',
+            order: 3,
+            category: 'tickets',
+            sidebar: {
+                showDropdown: true,
+                sections: [
+                    {
+                        label: 'Tickets',
+                        items: [
+                            {
+                                label: 'Panels',
+                                url: '/panel/:guildId(\\d+)/ticket/panels',
+                            },
+                        ],
+                    },
+                ],
+            },
+        });
     }
 }

--- a/src/modules/userPanel/routes/UserPanelTicketPanelDelete.ts
+++ b/src/modules/userPanel/routes/UserPanelTicketPanelDelete.ts
@@ -1,0 +1,33 @@
+import { Route, RouteMethod, ServiceContainer } from 'zumito-framework';
+import { Client, PermissionFlagsBits } from 'discord.js';
+import { UserPanelAuthService } from '../services/UserPanelAuthService';
+import { TicketPanelService } from '../../tickets/services/TicketPanelService';
+
+export class UserPanelTicketPanelDelete extends Route {
+    method = RouteMethod.post;
+    path = '/panel/:guildId(\\d+)/ticket/panels/delete/:panelId';
+
+    constructor(
+        private client: Client = ServiceContainer.getService(Client),
+        private authService = ServiceContainer.getService(UserPanelAuthService),
+        private ticketPanelService = new TicketPanelService(),
+    ) {
+        super();
+    }
+
+    async execute(req: any, res: any) {
+        const auth = await this.authService.isLoginValid(req);
+        if (!auth.isValid) return res.redirect('/panel/login');
+        const guildId = req.params.guildId as string;
+        const userId = auth.data.discordUserData.id;
+        const guild = this.client.guilds.cache.get(guildId);
+        if (!guild) return res.status(404).send('Servidor no encontrado');
+        let member = guild.members.cache.get(userId);
+        if (!member) member = await guild.members.fetch(userId).catch(() => null);
+        if (!member || !(member.permissions.has(PermissionFlagsBits.Administrator) || member.permissions.has(PermissionFlagsBits.ManageGuild) || guild.ownerId === userId)) {
+            return res.status(403).send('No tienes permisos en este servidor');
+        }
+        await this.ticketPanelService.deleteTicketPanel(req.params.panelId);
+        res.redirect(`/panel/${guildId}/ticket/panels`);
+    }
+}

--- a/src/modules/userPanel/routes/UserPanelTicketPanelEditor.ts
+++ b/src/modules/userPanel/routes/UserPanelTicketPanelEditor.ts
@@ -1,0 +1,93 @@
+import { Route, RouteMethod, ServiceContainer } from 'zumito-framework';
+import { Client, PermissionFlagsBits, ChannelType } from 'discord.js';
+import { UserPanelAuthService } from '../services/UserPanelAuthService';
+import { UserPanelViewService } from '../services/UserPanelViewService';
+import { TicketPanelService } from '../../tickets/services/TicketPanelService';
+import ejs from 'ejs';
+import path, { dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export class UserPanelTicketPanelEditor extends Route {
+    method = RouteMethod.get;
+    path = '/panel/:guildId(\\d+)/ticket/panels/editor/:panelId?';
+
+    constructor(
+        private client: Client = ServiceContainer.getService(Client),
+        private authService = ServiceContainer.getService(UserPanelAuthService),
+        private ticketPanelService = new TicketPanelService(),
+    ) {
+        super();
+    }
+
+    async execute(req: any, res: any) {
+        const auth = await this.authService.isLoginValid(req);
+        if (!auth.isValid) return res.redirect('/panel/login');
+        const guildId = req.params.guildId as string;
+        const userId = auth.data.discordUserData.id;
+        const guild = this.client.guilds.cache.get(guildId);
+        if (!guild) return res.status(404).send('Servidor no encontrado');
+        let member = guild.members.cache.get(userId);
+        if (!member) member = await guild.members.fetch(userId).catch(() => null);
+        if (!member || !(member.permissions.has(PermissionFlagsBits.Administrator) || member.permissions.has(PermissionFlagsBits.ManageGuild) || guild.ownerId === userId)) {
+            return res.status(403).send('No tienes permisos en este servidor');
+        }
+        let panel = null;
+        if (req.params.panelId) {
+            panel = await this.ticketPanelService.getTicketPanel(req.params.panelId).catch(() => null);
+        }
+        const channels = guild.channels.cache
+            .filter(channel => channel.type === ChannelType.GuildText)
+            .map(channel => ({ id: channel.id, name: channel.name }));
+        const content = await ejs.renderFile(
+            path.resolve(__dirname, '../views/ticket-panel-editor.ejs'),
+            { guild, panel, channels }
+        );
+        const view = new UserPanelViewService();
+        const html = await view.render({ content, reqPath: req.path, req, res });
+        res.send(html);
+    }
+}
+
+export class UserPanelTicketPanelEditorSave extends Route {
+    method = RouteMethod.post;
+    path = '/panel/:guildId(\\d+)/ticket/panels/editor/:panelId?';
+
+    constructor(
+        private client: Client = ServiceContainer.getService(Client),
+        private authService = ServiceContainer.getService(UserPanelAuthService),
+        private ticketPanelService = new TicketPanelService(),
+    ) {
+        super();
+    }
+
+    async execute(req: any, res: any) {
+        const auth = await this.authService.isLoginValid(req);
+        if (!auth.isValid) return res.redirect('/panel/login');
+        const guildId = req.params.guildId as string;
+        const userId = auth.data.discordUserData.id;
+        const guild = this.client.guilds.cache.get(guildId);
+        if (!guild) return res.status(404).send('Servidor no encontrado');
+        let member = guild.members.cache.get(userId);
+        if (!member) member = await guild.members.fetch(userId).catch(() => null);
+        if (!member || !(member.permissions.has(PermissionFlagsBits.Administrator) || member.permissions.has(PermissionFlagsBits.ManageGuild) || guild.ownerId === userId)) {
+            return res.status(403).send('No tienes permisos en este servidor');
+        }
+        const panelData = {
+            embed: {
+                title: req.body.title,
+                description: req.body.description,
+                color: req.body.color,
+            },
+            button: { label: req.body.buttonLabel },
+            channelId: req.body.channelId,
+        };
+        if (req.params.panelId) {
+            await this.ticketPanelService.updateTicketPanel(req.params.panelId, panelData);
+        } else {
+            await this.ticketPanelService.createTicketPanel(guildId, panelData);
+        }
+        res.redirect(`/panel/${guildId}/ticket/panels`);
+    }
+}

--- a/src/modules/userPanel/routes/UserPanelTicketPanelSend.ts
+++ b/src/modules/userPanel/routes/UserPanelTicketPanelSend.ts
@@ -1,0 +1,35 @@
+import { Route, RouteMethod, ServiceContainer } from 'zumito-framework';
+import { Client, PermissionFlagsBits } from 'discord.js';
+import { UserPanelAuthService } from '../services/UserPanelAuthService';
+import { TicketPanelService } from '../../tickets/services/TicketPanelService';
+
+export class UserPanelTicketPanelSend extends Route {
+    method = RouteMethod.post;
+    path = '/panel/:guildId(\\d+)/ticket/panels/send/:panelId';
+
+    constructor(
+        private client: Client = ServiceContainer.getService(Client),
+        private authService = ServiceContainer.getService(UserPanelAuthService),
+        private ticketPanelService = new TicketPanelService(),
+    ) {
+        super();
+    }
+
+    async execute(req: any, res: any) {
+        const auth = await this.authService.isLoginValid(req);
+        if (!auth.isValid) return res.redirect('/panel/login');
+        const guildId = req.params.guildId as string;
+        const userId = auth.data.discordUserData.id;
+        const guild = this.client.guilds.cache.get(guildId);
+        if (!guild) return res.status(404).send('Servidor no encontrado');
+        let member = guild.members.cache.get(userId);
+        if (!member) member = await guild.members.fetch(userId).catch(() => null);
+        if (!member || !(member.permissions.has(PermissionFlagsBits.Administrator) || member.permissions.has(PermissionFlagsBits.ManageGuild) || guild.ownerId === userId)) {
+            return res.status(403).send('No tienes permisos en este servidor');
+        }
+        const panel = await this.ticketPanelService.getTicketPanel(req.params.panelId).catch(() => null);
+        if (!panel) return res.status(404).send('Panel no encontrado');
+        await this.ticketPanelService.sendTicketPanel(req.params.panelId, panel.channelId);
+        res.redirect(`/panel/${guildId}/ticket/panels`);
+    }
+}

--- a/src/modules/userPanel/routes/UserPanelTicketPanels.ts
+++ b/src/modules/userPanel/routes/UserPanelTicketPanels.ts
@@ -1,0 +1,45 @@
+import { Route, RouteMethod, ServiceContainer } from 'zumito-framework';
+import { Client, PermissionFlagsBits } from 'discord.js';
+import { UserPanelAuthService } from '../services/UserPanelAuthService';
+import { UserPanelViewService } from '../services/UserPanelViewService';
+import { TicketPanelService } from '../../tickets/services/TicketPanelService';
+import ejs from 'ejs';
+import path, { dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export class UserPanelTicketPanels extends Route {
+    method = RouteMethod.get;
+    path = '/panel/:guildId(\\d+)/ticket/panels';
+
+    constructor(
+        private client: Client = ServiceContainer.getService(Client),
+        private authService = ServiceContainer.getService(UserPanelAuthService),
+        private ticketPanelService = new TicketPanelService(),
+    ) {
+        super();
+    }
+
+    async execute(req: any, res: any) {
+        const auth = await this.authService.isLoginValid(req);
+        if (!auth.isValid) return res.redirect('/panel/login');
+        const guildId = req.params.guildId as string;
+        const userId = auth.data.discordUserData.id;
+        const guild = this.client.guilds.cache.get(guildId);
+        if (!guild) return res.status(404).send('Servidor no encontrado');
+        let member = guild.members.cache.get(userId);
+        if (!member) member = await guild.members.fetch(userId).catch(() => null);
+        if (!member || !(member.permissions.has(PermissionFlagsBits.Administrator) || member.permissions.has(PermissionFlagsBits.ManageGuild) || guild.ownerId === userId)) {
+            return res.status(403).send('No tienes permisos en este servidor');
+        }
+        const panels = await this.ticketPanelService.getTicketPanels(guildId);
+        const content = await ejs.renderFile(
+            path.resolve(__dirname, '../views/ticket-panels.ejs'),
+            { guild, panels }
+        );
+        const view = new UserPanelViewService();
+        const html = await view.render({ content, reqPath: req.path, req, res });
+        res.send(html);
+    }
+}

--- a/src/modules/userPanel/views/ticket-panel-editor.ejs
+++ b/src/modules/userPanel/views/ticket-panel-editor.ejs
@@ -1,0 +1,31 @@
+<div class="card mt-6">
+    <form method="POST">
+        <div class="mb-4">
+            <label class="block mb-1 text-sm">Título</label>
+            <input type="text" name="title" value="<%= panel?.embed?.title || '' %>" class="w-full px-3 py-2 rounded bg-discord-dark-300 text-white" />
+        </div>
+        <div class="mb-4">
+            <label class="block mb-1 text-sm">Descripción</label>
+            <textarea name="description" class="w-full px-3 py-2 rounded bg-discord-dark-300 text-white"><%= panel?.embed?.description || '' %></textarea>
+        </div>
+        <div class="mb-4">
+            <label class="block mb-1 text-sm">Color</label>
+            <input type="color" name="color" value="<%= panel?.embed?.color || '#000000' %>" class="w-full h-10 bg-discord-dark-300 border border-discord-dark-100 rounded cursor-pointer" />
+        </div>
+        <div class="mb-4">
+            <label class="block mb-1 text-sm">Texto del Botón</label>
+            <input type="text" name="buttonLabel" value="<%= panel?.button?.label || '' %>" class="w-full px-3 py-2 rounded bg-discord-dark-300 text-white" />
+        </div>
+        <div class="mb-4">
+            <label class="block mb-1 text-sm">Canal de destino</label>
+            <select name="channelId" class="w-full bg-discord-dark-300 text-white px-3 py-2 rounded">
+                <% channels.forEach(c => { %>
+                    <option value="<%= c.id %>" <%= panel && panel.channelId === c.id ? 'selected' : '' %>>#<%= c.name %></option>
+                <% }) %>
+            </select>
+        </div>
+        <div class="flex justify-end">
+            <button type="submit" class="btn-primary">Guardar</button>
+        </div>
+    </form>
+</div>

--- a/src/modules/userPanel/views/ticket-panels.ejs
+++ b/src/modules/userPanel/views/ticket-panels.ejs
@@ -1,0 +1,32 @@
+<div class="card mt-6">
+    <div class="flex items-center justify-between mb-4">
+        <h2 class="text-xl font-bold">Ticket Panels</h2>
+        <a href="/panel/<%= guild.id %>/ticket/panels/editor" class="btn-primary">Crear Nuevo Panel</a>
+    </div>
+    <% if (panels.length === 0) { %>
+        <p>No hay paneles configurados.</p>
+    <% } else { %>
+        <table class="min-w-full text-left">
+            <thead>
+                <tr>
+                    <th class="pb-2">ID</th>
+                    <th class="pb-2">Título</th>
+                    <th class="pb-2">Acciones</th>
+                </tr>
+            </thead>
+            <tbody>
+                <% panels.forEach(panel => { %>
+                    <tr class="border-t border-discord-dark-300">
+                        <td class="py-2"><%= panel._id %></td>
+                        <td class="py-2"><%= panel.embed?.title || '' %></td>
+                        <td class="py-2 space-x-2">
+                            <a href="/panel/<%= guild.id %>/ticket/panels/editor/<%= panel._id %>" class="btn-primary">Editar</a>
+                            <button disabled class="btn-primary">Enviar</button>
+                            <button disabled class="btn-primary">Eliminar</button>
+                        </td>
+                    </tr>
+                <% }) %>
+            </tbody>
+        </table>
+    <% } %>
+</div>

--- a/src/modules/userPanel/views/ticket-panels.ejs
+++ b/src/modules/userPanel/views/ticket-panels.ejs
@@ -17,10 +17,10 @@
             <tbody>
                 <% panels.forEach(panel => { %>
                     <tr class="border-t border-discord-dark-300">
-                        <td class="py-2"><%= panel._id %></td>
+                        <td class="py-2"><%= panel._id.toString() %></td>
                         <td class="py-2"><%= panel.embed?.title || '' %></td>
                         <td class="py-2 space-x-2">
-                            <a href="/panel/<%= guild.id %>/ticket/panels/editor/<%= panel._id %>" class="btn-primary">Editar</a>
+                            <a href="/panel/<%= guild.id %>/ticket/panels/editor/<%= panel._id.toString() %>" class="btn-primary">Editar</a>
                             <button disabled class="btn-primary">Enviar</button>
                             <button disabled class="btn-primary">Eliminar</button>
                         </td>

--- a/src/modules/userPanel/views/ticket-panels.ejs
+++ b/src/modules/userPanel/views/ticket-panels.ejs
@@ -21,8 +21,12 @@
                         <td class="py-2"><%= panel.embed?.title || '' %></td>
                         <td class="py-2 space-x-2">
                             <a href="/panel/<%= guild.id %>/ticket/panels/editor/<%= panel._id.toString() %>" class="btn-primary">Editar</a>
-                            <button disabled class="btn-primary">Enviar</button>
-                            <button disabled class="btn-primary">Eliminar</button>
+                            <form method="POST" action="/panel/<%= guild.id %>/ticket/panels/send/<%= panel._id.toString() %>" class="inline-block">
+                                <button type="submit" class="btn-primary">Enviar</button>
+                            </form>
+                            <form method="POST" action="/panel/<%= guild.id %>/ticket/panels/delete/<%= panel._id.toString() %>" class="inline-block" onsubmit="return confirm('¿Eliminar panel?');">
+                                <button type="submit" class="btn-primary">Eliminar</button>
+                            </form>
                         </td>
                     </tr>
                 <% }) %>


### PR DESCRIPTION
## Summary
- add TicketPanelService to manage ticket panel data and send embeds
- add user panel routes to list and edit ticket panels
- add views for listing and editing ticket panels
- register Ticket Panels in user panel navigation
- group ticket panel navigation under Tickets section
- improve ticket panel editor with channel dropdown and color picker

## Testing
- `npx eslint .` *(failed to run: Cannot find package '@typescript-eslint/eslint-plugin')*

------
https://chatgpt.com/codex/tasks/task_e_687fe53d27ec832f8173e31e0261bcee