### PR TITLE
Add ticket dashboard panel

### DIFF
--- a/src/modules/userPanel/routes/UserPanelTicket.ts
+++ b/src/modules/userPanel/routes/UserPanelTicket.ts
@@ -1,0 +1,79 @@
+import { Route, RouteMethod, ServiceContainer, ZumitoFramework } from "zumito-framework";
+import { Client, PermissionFlagsBits } from "zumito-framework/discord";
+import { UserPanelAuthService } from "../services/UserPanelAuthService";
+import { UserPanelViewService } from "../services/UserPanelViewService";
+import ejs from "ejs";
+import path, { dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export class UserPanelTicket extends Route {
+    method = RouteMethod.get;
+    path = '/panel/:guildId(\\d+)/ticket';
+
+    constructor(
+        private client: Client = ServiceContainer.getService(Client),
+        private framework: ZumitoFramework = ServiceContainer.getService(ZumitoFramework),
+        private auth = ServiceContainer.getService(UserPanelAuthService),
+    ) {
+        super();
+    }
+
+    async execute(req: any, res: any) {
+        const authData = await this.auth.isLoginValid(req);
+        if (!authData.isValid) {
+            return res.redirect('/panel/login');
+        }
+
+        const userId = authData.data.discordUserData.id;
+        const guildId = req.params.guildId as string;
+        const guild = this.client.guilds.cache.get(guildId);
+        if (!guild) return res.status(404).send('Servidor no encontrado');
+
+        let member = guild.members.cache.get(userId);
+        if (!member) {
+            member = await guild.members.fetch(userId).catch(() => null);
+        }
+        if (!member || !(member.permissions.has(PermissionFlagsBits.Administrator) || member.permissions.has(PermissionFlagsBits.ManageGuild) || guild.ownerId === userId)) {
+            return res.status(403).send('No tienes permisos en este servidor');
+        }
+
+        const TicketModel = this.framework.database.models.Ticket;
+        const totalTickets = await TicketModel.count({ where: { guildId } }).catch(() => 0);
+        const openTickets = await TicketModel.count({ where: { guildId, status: 'open' } }).catch(() => 0);
+        const closedTickets = await TicketModel.count({ where: { guildId, status: 'closed' } }).catch(() => 0);
+        const recentTickets = await TicketModel.all({
+            where: { guildId },
+            limit: 5,
+            order: 'createdAt DESC'
+        }).catch(() => []);
+
+        const tickets = [] as Array<{ channelId: string; userTag: string; status: string; createdAt: Date }>;
+        for (const ticket of recentTickets) {
+            const user = await this.client.users.fetch(ticket.userId).catch(() => null);
+            tickets.push({
+                channelId: ticket.channelId,
+                userTag: user ? `${user.username}#${user.discriminator}` : ticket.userId,
+                status: ticket.status,
+                createdAt: ticket.createdAt,
+            });
+        }
+
+        const content = await ejs.renderFile(
+            path.resolve(__dirname, '../views/ticket-dashboard.ejs'),
+            {
+                guild,
+                stats: {
+                    total: totalTickets,
+                    open: openTickets,
+                    closed: closedTickets,
+                },
+                tickets,
+            }
+        );
+        const view = new UserPanelViewService();
+        const html = await view.render({ content, reqPath: req.path, req, res });
+        res.send(html);
+    }
+}

--- a/src/modules/userPanel/views/ticket-dashboard.ejs
+++ b/src/modules/userPanel/views/ticket-dashboard.ejs
@@ -1,0 +1,45 @@
+<div class="card">
+    <h2 class="text-xl font-bold mb-4">Resumen de Tickets</h2>
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-4 text-center">
+        <div class="bg-discord-dark-300 rounded p-4">
+            <div class="text-discord-gray-300 text-sm">Totales</div>
+            <div class="text-2xl font-bold text-discord-white"><%= stats.total %></div>
+        </div>
+        <div class="bg-discord-dark-300 rounded p-4">
+            <div class="text-discord-gray-300 text-sm">Abiertos</div>
+            <div class="text-2xl font-bold text-discord-white"><%= stats.open %></div>
+        </div>
+        <div class="bg-discord-dark-300 rounded p-4">
+            <div class="text-discord-gray-300 text-sm">Cerrados</div>
+            <div class="text-2xl font-bold text-discord-white"><%= stats.closed %></div>
+        </div>
+    </div>
+</div>
+
+<div class="card mt-6">
+    <h2 class="text-xl font-bold mb-4">Últimos Tickets</h2>
+    <% if (tickets.length === 0) { %>
+        <p>No hay tickets recientes.</p>
+    <% } else { %>
+        <table class="min-w-full text-left">
+            <thead>
+                <tr>
+                    <th class="pb-2">Canal</th>
+                    <th class="pb-2">Usuario</th>
+                    <th class="pb-2">Estado</th>
+                    <th class="pb-2">Creado</th>
+                </tr>
+            </thead>
+            <tbody>
+                <% tickets.forEach(t => { %>
+                    <tr class="border-t border-discord-dark-300">
+                        <td class="py-2"><%= t.channelId %></td>
+                        <td class="py-2"><%= t.userTag %></td>
+                        <td class="py-2"><%= t.status %></td>
+                        <td class="py-2"><%= t.createdAt.toLocaleString() %></td>
+                    </tr>
+                <% }) %>
+            </tbody>
+        </table>
+    <% } %>
+</div>


### PR DESCRIPTION
## Summary
- add `/panel/:guildId/ticket` route for a simple ticket dashboard
- show basic ticket stats and latest tickets in a new view

## Testing
- `npx eslint .` *(fails: Cannot find package '@typescript-eslint/eslint-plugin' and installation blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68800a26c62c832f8afaf8190ed4ca2b