### PR TITLE
Add confession command with user panel

### DIFF
--- a/src/modules/confessions/commands/confession.ts
+++ b/src/modules/confessions/commands/confession.ts
@@ -1,0 +1,40 @@
+import { ActionRowBuilder, ModalBuilder, TextInputBuilder, TextInputStyle, MessageFlags } from 'zumito-framework/discord';
+import { Command, CommandParameters, CommandType, ModalSubmitParameters, ServiceContainer } from 'zumito-framework';
+import { ConfessionService } from '../services/ConfessionService.js';
+
+export class ConfessionCommand extends Command {
+    name = 'confession';
+    description = 'Send an anonymous confession';
+    categories = ['utils'];
+    botPermissions = ['VIEW_CHANNEL', 'SEND_MESSAGES'];
+    type = CommandType.any;
+
+    async execute({ interaction }: CommandParameters): Promise<void> {
+        if (!interaction) return;
+        const modal = new ModalBuilder()
+            .setCustomId(`${this.name}.send`)
+            .setTitle('Send Confession');
+
+        const input = new TextInputBuilder()
+            .setCustomId('confession')
+            .setLabel('Your Confession')
+            .setStyle(TextInputStyle.Paragraph)
+            .setRequired(true);
+
+        const row: any = new ActionRowBuilder<TextInputBuilder>().addComponents(input);
+        modal.addComponents(row);
+        await interaction.showModal(modal);
+    }
+
+    async modalSubmit({ interaction, path }: ModalSubmitParameters): Promise<void> {
+        if (path[1] !== 'send') return;
+        const confession = interaction.fields.getTextInputValue('confession');
+        const service = ServiceContainer.getService(ConfessionService) as ConfessionService;
+        const success = await service.sendConfession(interaction.guild!.id, confession);
+        if (!success) {
+            await interaction.reply({ content: 'Confession channel not configured.', flags: MessageFlags.Ephemeral });
+            return;
+        }
+        await interaction.reply({ content: 'Your confession has been sent.', flags: MessageFlags.Ephemeral });
+    }
+}

--- a/src/modules/confessions/index.ts
+++ b/src/modules/confessions/index.ts
@@ -1,0 +1,38 @@
+import { Module, ServiceContainer, ZumitoFramework } from 'zumito-framework';
+import { UserPanelNavigationService } from '@zumito-team/user-panel-module/services/UserPanelNavigationService';
+import { ConfessionService } from './services/ConfessionService.js';
+
+export class ConfessionModule extends Module {
+    requeriments = {
+        services: ['UserPanelNavigationService']
+    };
+
+    constructor(modulePath: string, framework: ZumitoFramework) {
+        super(modulePath);
+        ServiceContainer.addService(ConfessionService, [], true);
+    }
+
+    async initialize(): Promise<void> {
+        await super.initialize();
+        const navigationService = ServiceContainer.getService(UserPanelNavigationService);
+        navigationService.registerItem({
+            id: 'confessions',
+            icon: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icon-tabler-message-circle-2"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M3 12a9 9 0 1 0 9 -9a9 9 0 0 0 -9 9"/><path d="M3 12v6l4 -4h8a3 3 0 0 0 3 -3v-1" /></svg>`,
+            label: 'Confesiones',
+            url: '/panel/:guildId/confessions',
+            order: 30,
+            category: 'config',
+            sidebar: {
+                showDropdown: false,
+                sections: [
+                    {
+                        label: 'Configuración',
+                        items: [
+                            { label: 'Confesiones', url: '/panel/:guildId/confessions' }
+                        ]
+                    }
+                ]
+            }
+        });
+    }
+}

--- a/src/modules/confessions/models/ConfessionConfig.ts
+++ b/src/modules/confessions/models/ConfessionConfig.ts
@@ -1,0 +1,14 @@
+import { DatabaseModel } from 'zumito-framework';
+
+export class ConfessionConfig extends DatabaseModel {
+    getModel(schema: any) {
+        return {
+            guildId: { type: schema.String, required: true, unique: true },
+            channelId: { type: schema.String, required: true }
+        };
+    }
+
+    define(model: any): void {
+        model.validatesUniquenessOf('guildId');
+    }
+}

--- a/src/modules/confessions/routes/UserPanelConfessions.ts
+++ b/src/modules/confessions/routes/UserPanelConfessions.ts
@@ -1,0 +1,48 @@
+import { Route, RouteMethod, ServiceContainer, ZumitoFramework } from 'zumito-framework';
+import { Client, PermissionFlagsBits } from 'zumito-framework/discord';
+import { UserPanelAuthService } from '@zumito-team/user-panel-module/services/UserPanelAuthService';
+import { UserPanelViewService } from '@zumito-team/user-panel-module/services/UserPanelViewService';
+import ejs from 'ejs';
+import path, { dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export class UserPanelConfessions extends Route {
+    method = RouteMethod.get;
+    path = '/panel/:guildId/confessions';
+
+    constructor(
+        private client: Client = ServiceContainer.getService(Client),
+        private framework: ZumitoFramework = ServiceContainer.getService(ZumitoFramework),
+        private auth = ServiceContainer.getService(UserPanelAuthService)
+    ) { super(); }
+
+    async execute(req: any, res: any) {
+        const authData = await this.auth.isLoginValid(req);
+        if (!authData.isValid) return res.redirect('/panel/login');
+
+        const userId = authData.data.discordUserData.id;
+        const guildId = req.params.guildId as string;
+        const guild = this.client.guilds.cache.get(guildId);
+        if (!guild) return res.status(404).send('Servidor no encontrado');
+        let member = guild.members.cache.get(userId);
+        if (!member) member = await guild.members.fetch(userId).catch(() => null);
+        if (!member || !(member.permissions.has(PermissionFlagsBits.Administrator) || member.permissions.has(PermissionFlagsBits.ManageGuild) || guild.ownerId === userId)) {
+            return res.status(403).send('No tienes permisos en este servidor');
+        }
+        const model = this.framework.database.models.ConfessionConfig;
+        let config = await model.findOne({ where: { guildId } }).catch(() => null);
+        if (!config) {
+            config = await model.create({ guildId, channelId: '' });
+        }
+        const channels = guild.channels.cache.filter(c => c.isTextBased()).map(c => ({ id: c.id, name: (c as any).name }));
+        const content = await ejs.renderFile(
+            path.resolve(__dirname, '../views/confessions-config.ejs'),
+            { guild, config, channels, botName: this.client.user?.username || 'Zumito Bot' }
+        );
+        const view = new UserPanelViewService();
+        const html = await view.render({ content, reqPath: req.path, req, res });
+        res.send(html);
+    }
+}

--- a/src/modules/confessions/routes/UserPanelConfessionsPost.ts
+++ b/src/modules/confessions/routes/UserPanelConfessionsPost.ts
@@ -1,0 +1,41 @@
+import { Route, RouteMethod, ServiceContainer, ZumitoFramework } from 'zumito-framework';
+import { Client, PermissionFlagsBits } from 'zumito-framework/discord';
+import { UserPanelAuthService } from '@zumito-team/user-panel-module/services/UserPanelAuthService';
+
+export class UserPanelConfessionsPost extends Route {
+    method = RouteMethod.post;
+    path = '/panel/:guildId/confessions';
+
+    constructor(
+        private client: Client = ServiceContainer.getService(Client),
+        private framework: ZumitoFramework = ServiceContainer.getService(ZumitoFramework),
+        private auth = ServiceContainer.getService(UserPanelAuthService)
+    ) { super(); }
+
+    async execute(req: any, res: any) {
+        const authData = await this.auth.isLoginValid(req);
+        if (!authData.isValid) return res.status(403).send('Access Denied');
+
+        const userId = authData.data.discordUserData.id;
+        const guildId = req.params.guildId;
+        const guild = this.client.guilds.cache.get(guildId);
+        if (!guild) return res.status(404).send('Servidor no encontrado');
+        let member = guild.members.cache.get(userId);
+        if (!member) member = await guild.members.fetch(userId).catch(() => null);
+        if (!member || !(member.permissions.has(PermissionFlagsBits.Administrator) || member.permissions.has(PermissionFlagsBits.ManageGuild) || guild.ownerId === userId)) {
+            return res.status(403).send('No tienes permisos en este servidor');
+        }
+        const { channelId } = req.body;
+        if (!channelId) return res.status(400).send('Faltan datos');
+
+        const model = this.framework.database.models.ConfessionConfig;
+        let config = await model.findOne({ where: { guildId } });
+        if (!config) {
+            await model.create({ guildId, channelId });
+        } else {
+            config.channelId = channelId;
+            await config.save();
+        }
+        res.redirect(`/panel/${guildId}/confessions`);
+    }
+}

--- a/src/modules/confessions/services/ConfessionService.ts
+++ b/src/modules/confessions/services/ConfessionService.ts
@@ -1,0 +1,23 @@
+import { Client, TextBasedChannel } from 'zumito-framework/discord';
+import { ServiceContainer, ZumitoFramework } from 'zumito-framework';
+
+export class ConfessionService {
+    private client: Client;
+    private framework: ZumitoFramework;
+
+    constructor() {
+        this.client = ServiceContainer.getService(Client);
+        this.framework = ServiceContainer.getService(ZumitoFramework);
+    }
+
+    async sendConfession(guildId: string, text: string): Promise<boolean> {
+        const model = this.framework.database.models.ConfessionConfig;
+        if (!model) return false;
+        const config = await model.findOne({ where: { guildId } }).catch(() => null);
+        if (!config) return false;
+        const channel = this.client.channels.cache.get(config.channelId) as TextBasedChannel | undefined;
+        if (!channel || !(channel as any).send) return false;
+        await (channel as any).send({ content: text });
+        return true;
+    }
+}

--- a/src/modules/confessions/services/ConfessionService.ts
+++ b/src/modules/confessions/services/ConfessionService.ts
@@ -1,23 +1,23 @@
-import { Client, TextBasedChannel } from 'zumito-framework/discord';
-import { ServiceContainer, ZumitoFramework } from 'zumito-framework';
+import { Client, EmbedBuilder, TextBasedChannel } from 'zumito-framework/discord';
+import { GuildDataGetter, ServiceContainer, ZumitoFramework } from 'zumito-framework';
 
 export class ConfessionService {
-    private client: Client;
-    private framework: ZumitoFramework;
 
-    constructor() {
-        this.client = ServiceContainer.getService(Client);
-        this.framework = ServiceContainer.getService(ZumitoFramework);
-    }
+    constructor(
+        private client: Client = ServiceContainer.getService(Client),
+        private guildDataGetter: GuildDataGetter = ServiceContainer.getService(GuildDataGetter), 
+    ) {}
 
     async sendConfession(guildId: string, text: string): Promise<boolean> {
-        const model = this.framework.database.models.ConfessionConfig;
-        if (!model) return false;
-        const config = await model.findOne({ where: { guildId } }).catch(() => null);
-        if (!config) return false;
-        const channel = this.client.channels.cache.get(config.channelId) as TextBasedChannel | undefined;
+        const guildSettings = await this.guildDataGetter.getGuildSettings(guildId);
+        const channel = this.client.channels.cache.get(guildSettings.confessionsChannelId) as TextBasedChannel | undefined;
         if (!channel || !(channel as any).send) return false;
-        await (channel as any).send({ content: text });
+        const embed = new EmbedBuilder()
+            .setTitle('Un usuario ha enviado una confesión')
+            .setDescription("```"+text+"```");
+        await (channel as any).send({ 
+            embeds: [embed],
+        });
         return true;
     }
 }

--- a/src/modules/confessions/translations/command/confession/en.json
+++ b/src/modules/confessions/translations/command/confession/en.json
@@ -1,0 +1,6 @@
+{
+    "description": "Send an anonymous confession.",
+    "modalTitle": "Send Confession",
+    "success": "Your confession has been sent.",
+    "notConfigured": "Confession channel is not configured."
+}

--- a/src/modules/confessions/translations/command/confession/es.json
+++ b/src/modules/confessions/translations/command/confession/es.json
@@ -1,0 +1,6 @@
+{
+    "description": "Envía una confesión anónima.",
+    "modalTitle": "Enviar Confesión",
+    "success": "Tu confesión ha sido enviada.",
+    "notConfigured": "El canal de confesiones no está configurado."
+}

--- a/src/modules/confessions/views/confessions-config.ejs
+++ b/src/modules/confessions/views/confessions-config.ejs
@@ -18,7 +18,7 @@
             <div class="relative">
                 <select name="channelId" class="w-full bg-discord-dark-300 text-white pl-10 pr-4 py-3 rounded-lg border border-discord-dark-100 focus:border-discord-primary focus:ring focus:ring-discord-primary/20 focus:outline-none transition-all duration-200">
                     <% channels.forEach(c => { %>
-                        <option value="<%= c.id %>" <%= config && config.channelId === c.id ? 'selected' : '' %>>#<%= c.name %></option>
+                        <option value="<%= c.id %>" <%= guildSettings && guildSettings.confessionsChannelId === c.id ? 'selected' : '' %>><%= c.name %></option>
                     <% }) %>
                 </select>
                 <div class="absolute left-3 top-1/2 transform -translate-y-1/2 text-discord-white/60">

--- a/src/modules/confessions/views/confessions-config.ejs
+++ b/src/modules/confessions/views/confessions-config.ejs
@@ -1,0 +1,40 @@
+<div class="card animate__animated animate__fadeIn">
+    <div class="flex items-center justify-between mb-6">
+        <h2 class="text-2xl font-bold text-discord-primary">Configurar Confesiones</h2>
+        <div class="p-2 bg-discord-primary/10 rounded-full">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 text-discord-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 8h10M7 12h4m1 8l-4-4H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-3l-4 4z" />
+            </svg>
+        </div>
+    </div>
+    <form method="POST" action="/panel/<%= guild.id %>/confessions" class="space-y-6">
+        <div class="transition-all duration-200 hover:shadow-md p-4 rounded-lg bg-discord-dark-400/30">
+            <label class="flex items-center gap-2 mb-2 text-lg font-medium text-discord-white">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-discord-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 8h10M7 12h4m1 8l-4-4H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-3l-4 4z" />
+                </svg>
+                Canal de Confesiones
+            </label>
+            <div class="relative">
+                <select name="channelId" class="w-full bg-discord-dark-300 text-white pl-10 pr-4 py-3 rounded-lg border border-discord-dark-100 focus:border-discord-primary focus:ring focus:ring-discord-primary/20 focus:outline-none transition-all duration-200">
+                    <% channels.forEach(c => { %>
+                        <option value="<%= c.id %>" <%= config && config.channelId === c.id ? 'selected' : '' %>>#<%= c.name %></option>
+                    <% }) %>
+                </select>
+                <div class="absolute left-3 top-1/2 transform -translate-y-1/2 text-discord-white/60">
+                    #
+                </div>
+            </div>
+            <p class="text-xs text-discord-white/60 mt-2">Selecciona el canal donde se publicarán las confesiones</p>
+        </div>
+        <div class="flex justify-end pt-2">
+            <button type="submit" class="btn-primary flex items-center gap-2 px-6 py-3 shadow-lg hover:translate-y-[-2px] transition-all duration-200">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+                </svg>
+                Guardar Configuración
+            </button>
+        </div>
+    </form>
+</div>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/4.1.1/animate.min.css" />


### PR DESCRIPTION
## Summary
- add `confession` command using a modal
- allow server admins to set confession channel from the user panel
- include service, model and routes for confessions

## Testing
- `npx eslint .` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*

------
https://chatgpt.com/codex/tasks/task_e_68815941ba5c832f875b06f54a7f6978