### PR TITLE
Add user panel lang config

### DIFF
--- a/src/modules/config/routes/UserPanelLang.ts
+++ b/src/modules/config/routes/UserPanelLang.ts
@@ -1,4 +1,4 @@
-import { Route, RouteMethod, ServiceContainer, ZumitoFramework } from "zumito-framework";
+import { GuildDataGetter, Route, RouteMethod, ServiceContainer, ZumitoFramework } from "zumito-framework";
 import { Client, PermissionFlagsBits } from "zumito-framework/discord";
 import { UserPanelAuthService } from "@zumito-team/user-panel-module/services/UserPanelAuthService";
 import { UserPanelViewService } from "@zumito-team/user-panel-module/services/UserPanelViewService";
@@ -16,6 +16,7 @@ export class UserPanelLang extends Route {
         private client: Client = ServiceContainer.getService(Client),
         private framework: ZumitoFramework = ServiceContainer.getService(ZumitoFramework),
         private auth = ServiceContainer.getService(UserPanelAuthService),
+        private guildDataGetter: GuildDataGetter = ServiceContainer.getService(GuildDataGetter),
     ) {
         super();
     }
@@ -40,12 +41,7 @@ export class UserPanelLang extends Route {
             return res.status(403).send('No tienes permisos en este servidor');
         }
 
-        const guildsCollection = this.framework.database.collection('guilds');
-        let guildSettings = await guildsCollection.findOne({ guildId }).catch(() => null);
-        if (!guildSettings) {
-            await guildsCollection.insertOne({ guildId, prefix: this.framework.settings.defaultPrefix, lang: 'en' });
-            guildSettings = await guildsCollection.findOne({ guildId });
-        }
+        const guildSettings = await this.guildDataGetter.getGuildSettings(guildId);
 
         const content = await ejs.renderFile(
             path.resolve(__dirname, '../views/lang-config.ejs'),

--- a/src/modules/config/routes/UserPanelLang.ts
+++ b/src/modules/config/routes/UserPanelLang.ts
@@ -1,0 +1,61 @@
+import { Route, RouteMethod, ServiceContainer, ZumitoFramework } from "zumito-framework";
+import { Client, PermissionFlagsBits } from "zumito-framework/discord";
+import { UserPanelAuthService } from "@zumito-team/user-panel-module/services/UserPanelAuthService";
+import { UserPanelViewService } from "@zumito-team/user-panel-module/services/UserPanelViewService";
+import ejs from "ejs";
+import path, { dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export class UserPanelLang extends Route {
+    method = RouteMethod.get;
+    path = '/panel/:guildId/lang';
+
+    constructor(
+        private client: Client = ServiceContainer.getService(Client),
+        private framework: ZumitoFramework = ServiceContainer.getService(ZumitoFramework),
+        private auth = ServiceContainer.getService(UserPanelAuthService),
+    ) {
+        super();
+    }
+
+    async execute(req: any, res: any) {
+        const authData = await this.auth.isLoginValid(req);
+        if (!authData.isValid) {
+            return res.redirect('/panel/login');
+        }
+
+        const userId = authData.data.discordUserData.id;
+        const guildId = req.params.guildId as string;
+        const guild = this.client.guilds.cache.get(guildId);
+        if (!guild) return res.status(404).send('Servidor no encontrado');
+
+        let member = guild.members.cache.get(userId);
+        if (!member) {
+            member = await guild.members.fetch(userId).catch(() => null);
+        }
+        if (!member || !(member.permissions.has(PermissionFlagsBits.Administrator) ||
+            member.permissions.has(PermissionFlagsBits.ManageGuild) || guild.ownerId === userId)) {
+            return res.status(403).send('No tienes permisos en este servidor');
+        }
+
+        const guildsCollection = this.framework.database.collection('guilds');
+        let guildSettings = await guildsCollection.findOne({ guildId }).catch(() => null);
+        if (!guildSettings) {
+            await guildsCollection.insertOne({ guildId, prefix: this.framework.settings.defaultPrefix, lang: 'en' });
+            guildSettings = await guildsCollection.findOne({ guildId });
+        }
+
+        const content = await ejs.renderFile(
+            path.resolve(__dirname, '../views/lang-config.ejs'),
+            {
+                guild,
+                lang: guildSettings.lang,
+            }
+        );
+        const view = new UserPanelViewService();
+        const html = await view.render({ content, reqPath: req.path, req, res });
+        res.send(html);
+    }
+}

--- a/src/modules/config/routes/UserPanelLangPost.ts
+++ b/src/modules/config/routes/UserPanelLangPost.ts
@@ -1,0 +1,43 @@
+import { Route, RouteMethod, ServiceContainer, ZumitoFramework } from "zumito-framework";
+import { Client, PermissionFlagsBits } from "zumito-framework/discord";
+import { UserPanelAuthService } from "@zumito-team/user-panel-module/services/UserPanelAuthService";
+
+export class UserPanelLangPost extends Route {
+    method = RouteMethod.post;
+    path = '/panel/:guildId/lang';
+
+    constructor(
+        private client: Client = ServiceContainer.getService(Client),
+        private framework: ZumitoFramework = ServiceContainer.getService(ZumitoFramework),
+        private auth = ServiceContainer.getService(UserPanelAuthService),
+    ) {
+        super();
+    }
+
+    async execute(req: any, res: any) {
+        const authData = await this.auth.isLoginValid(req);
+        if (!authData.isValid) return res.status(403).send('Access Denied');
+
+        const userId = authData.data.discordUserData.id;
+        const guildId = req.params.guildId as string;
+        const guild = this.client.guilds.cache.get(guildId);
+        if (!guild) return res.status(404).send('Servidor no encontrado');
+        let member = guild.members.cache.get(userId);
+        if (!member) member = await guild.members.fetch(userId).catch(() => null);
+        if (!member || !(member.permissions.has(PermissionFlagsBits.Administrator) ||
+            member.permissions.has(PermissionFlagsBits.ManageGuild) || guild.ownerId === userId)) {
+            return res.status(403).send('No tienes permisos en este servidor');
+        }
+
+        const { lang } = req.body || {};
+        if (!lang || !['en', 'es'].includes(lang)) return res.status(400).send('Idioma inválido');
+
+        await this.framework.database.collection('guilds').updateOne(
+            { guildId },
+            { $set: { lang } },
+            { upsert: true }
+        );
+
+        res.redirect(`/panel/${guildId}/lang`);
+    }
+}

--- a/src/modules/config/routes/UserPanelLangPost.ts
+++ b/src/modules/config/routes/UserPanelLangPost.ts
@@ -33,7 +33,7 @@ export class UserPanelLangPost extends Route {
         if (!lang || !['en', 'es'].includes(lang)) return res.status(400).send('Idioma inválido');
 
         await this.framework.database.collection('guilds').updateOne(
-            { guildId },
+            { guild_id: guildId },
             { $set: { lang } },
             { upsert: true }
         );

--- a/src/modules/config/views/lang-config.ejs
+++ b/src/modules/config/views/lang-config.ejs
@@ -1,0 +1,28 @@
+<div class="card animate__animated animate__fadeIn">
+    <div class="flex items-center justify-between mb-6">
+        <h2 class="text-2xl font-bold text-discord-primary">Configurar Idioma</h2>
+    </div>
+    <form method="POST" action="/panel/<%= guild.id %>/lang" class="space-y-6">
+        <div class="transition-all duration-200 hover:shadow-md p-4 rounded-lg bg-discord-dark-400/30">
+            <label class="flex items-center gap-2 mb-2 text-lg font-medium text-discord-white">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-discord-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
+                </svg>
+                Idioma del Servidor
+            </label>
+            <select name="lang" class="w-full bg-discord-dark-300 text-white px-4 py-3 rounded-lg border border-discord-dark-100 focus:border-discord-primary focus:ring focus:ring-discord-primary/20 focus:outline-none transition-all duration-200">
+                <option value="en" <%= lang === 'en' ? 'selected' : '' %>>English</option>
+                <option value="es" <%= lang === 'es' ? 'selected' : '' %>>Español</option>
+            </select>
+        </div>
+        <div class="flex justify-end pt-2">
+            <button type="submit" class="btn-primary flex items-center gap-2 px-6 py-3 shadow-lg hover:translate-y-[-2px] transition-all duration-200">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+                </svg>
+                Guardar
+            </button>
+        </div>
+    </form>
+</div>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/4.1.1/animate.min.css" />


### PR DESCRIPTION
## Summary
- add GET/POST routes for user panel language configuration
- add lang configuration view with dropdown

## Testing
- `npx eslint .` *(fails: cannot find package '@typescript-eslint/eslint-plugin')*

------
https://chatgpt.com/codex/tasks/task_e_688159a117e4832f8f8899904481181f