### PR TITLE
Add call module

### DIFF
--- a/src/modules/calls/commands/call.ts
+++ b/src/modules/calls/commands/call.ts
@@ -1,0 +1,27 @@
+import { EmbedBuilder } from 'zumito-framework/discord';
+import { Command, CommandParameters, CommandType, ServiceContainer } from 'zumito-framework';
+import { CallService } from '../services/CallService.js';
+
+export class CallCommand extends Command {
+    name = 'call';
+    description = 'Connect with another server.';
+    categories = ['utils'];
+    botPermissions = ['VIEW_CHANNEL', 'SEND_MESSAGES'];
+    type = CommandType.any;
+
+    async execute({ message, interaction, trans }: CommandParameters): Promise<void> {
+        const guildId = (message || interaction)?.guild?.id;
+        if (!guildId) return;
+        const service = ServiceContainer.getService(CallService) as CallService;
+        const result = await service.requestCall(guildId);
+        const embed = new EmbedBuilder();
+        if (result === 'notConfigured') {
+            embed.setDescription(trans('notConfigured'));
+        } else if (result === 'waiting') {
+            embed.setDescription(trans('waiting'));
+        } else {
+            embed.setDescription(trans('connected'));
+        }
+        (message || interaction)?.reply({ embeds: [embed], allowedMentions: { repliedUser: false } });
+    }
+}

--- a/src/modules/calls/index.ts
+++ b/src/modules/calls/index.ts
@@ -1,0 +1,36 @@
+import { Module, ServiceContainer } from 'zumito-framework';
+import { UserPanelNavigationService } from '@zumito-team/user-panel-module/services/UserPanelNavigationService';
+import { CallService } from './services/CallService.js';
+
+export class CallModule extends Module {
+    requeriments = {
+        services: ['UserPanelNavigationService']
+    };
+
+    constructor(modulePath: string) {
+        super(modulePath);
+        ServiceContainer.addService(CallService, [], true);
+    }
+
+    async initialize(): Promise<void> {
+        await super.initialize();
+        const navigationService = ServiceContainer.getService(UserPanelNavigationService);
+        navigationService.registerItem({
+            id: 'calls',
+            icon: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icon-tabler-phone"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M4 4h5l5 5v6l-5 5h-5z"/></svg>`,
+            label: 'Calls',
+            url: '/panel/:guildId/calls',
+            order: 30,
+            category: 'config',
+            sidebar: {
+                showDropdown: false,
+                sections: [
+                    {
+                        label: 'Configuration',
+                        items: [{ label: 'Calls', url: '/panel/:guildId/calls' }]
+                    }
+                ]
+            }
+        });
+    }
+}

--- a/src/modules/calls/index.ts
+++ b/src/modules/calls/index.ts
@@ -15,22 +15,8 @@ export class CallModule extends Module {
     async initialize(): Promise<void> {
         await super.initialize();
         const navigationService = ServiceContainer.getService(UserPanelNavigationService);
-        navigationService.registerItem({
-            id: 'calls',
-            icon: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icon-tabler-phone"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M4 4h5l5 5v6l-5 5h-5z"/></svg>`,
-            label: 'Calls',
-            url: '/panel/:guildId/calls',
-            order: 30,
-            category: 'config',
-            sidebar: {
-                showDropdown: false,
-                sections: [
-                    {
-                        label: 'Configuration',
-                        items: [{ label: 'Calls', url: '/panel/:guildId/calls' }]
-                    }
-                ]
-            }
-        });
+        navigationService.registerSubItems('dashboard', 'General', [
+            { id: 'calls', label: 'Calls', url: '/panel/:guildId/calls' }
+        ]);
     }
 }

--- a/src/modules/calls/routes/UserPanelCalls.ts
+++ b/src/modules/calls/routes/UserPanelCalls.ts
@@ -1,0 +1,45 @@
+import { GuildDataGetter, Route, RouteMethod, ServiceContainer, ZumitoFramework } from 'zumito-framework';
+import { Client, PermissionFlagsBits } from 'zumito-framework/discord';
+import { UserPanelAuthService } from '@zumito-team/user-panel-module/services/UserPanelAuthService';
+import { UserPanelViewService } from '@zumito-team/user-panel-module/services/UserPanelViewService';
+import ejs from 'ejs';
+import path, { dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export class UserPanelCalls extends Route {
+    method = RouteMethod.get;
+    path = '/panel/:guildId/calls';
+
+    constructor(
+        private client: Client = ServiceContainer.getService(Client),
+        private framework: ZumitoFramework = ServiceContainer.getService(ZumitoFramework),
+        private auth = ServiceContainer.getService(UserPanelAuthService),
+        private guildDataGetter = ServiceContainer.getService(GuildDataGetter)
+    ) { super(); }
+
+    async execute(req: any, res: any) {
+        const authData = await this.auth.isLoginValid(req);
+        if (!authData.isValid) return res.redirect('/panel/login');
+
+        const userId = authData.data.discordUserData.id;
+        const guildId = req.params.guildId as string;
+        const guild = this.client.guilds.cache.get(guildId);
+        if (!guild) return res.status(404).send('Servidor no encontrado');
+        let member = guild.members.cache.get(userId);
+        if (!member) member = await guild.members.fetch(userId).catch(() => null);
+        if (!member || !(member.permissions.has(PermissionFlagsBits.Administrator) || member.permissions.has(PermissionFlagsBits.ManageGuild) || guild.ownerId === userId)) {
+            return res.status(403).send('No tienes permisos en este servidor');
+        }
+        const guildSettings = await this.guildDataGetter.getGuildSettings(guildId);
+        const categories = guild.channels.cache.filter(c => c.type === 4).map(c => ({ id: c.id, name: (c as any).name }));
+        const content = await ejs.renderFile(
+            path.resolve(__dirname, '../views/calls-config.ejs'),
+            { guild, guildSettings, categories, botName: this.client.user?.username || 'Zumito Bot' }
+        );
+        const view = new UserPanelViewService();
+        const html = await view.render({ content, reqPath: req.path, req, res });
+        res.send(html);
+    }
+}

--- a/src/modules/calls/routes/UserPanelCallsPost.ts
+++ b/src/modules/calls/routes/UserPanelCallsPost.ts
@@ -1,0 +1,39 @@
+import { GuildDataGetter, Route, RouteMethod, ServiceContainer, ZumitoFramework } from 'zumito-framework';
+import { Client, PermissionFlagsBits } from 'zumito-framework/discord';
+import { UserPanelAuthService } from '@zumito-team/user-panel-module/services/UserPanelAuthService';
+
+export class UserPanelCallsPost extends Route {
+    method = RouteMethod.post;
+    path = '/panel/:guildId/calls';
+
+    constructor(
+        private client: Client = ServiceContainer.getService(Client),
+        private framework: ZumitoFramework = ServiceContainer.getService(ZumitoFramework),
+        private auth = ServiceContainer.getService(UserPanelAuthService),
+        private guildDataGetter = ServiceContainer.getService(GuildDataGetter)
+    ) { super(); }
+
+    async execute(req: any, res: any) {
+        const authData = await this.auth.isLoginValid(req);
+        if (!authData.isValid) return res.status(403).send('Access Denied');
+
+        const userId = authData.data.discordUserData.id;
+        const guildId = req.params.guildId as string;
+        const guild = this.client.guilds.cache.get(guildId);
+        if (!guild) return res.status(404).send('Servidor no encontrado');
+        let member = guild.members.cache.get(userId);
+        if (!member) member = await guild.members.fetch(userId).catch(() => null);
+        if (!member || !(member.permissions.has(PermissionFlagsBits.Administrator) || member.permissions.has(PermissionFlagsBits.ManageGuild) || guild.ownerId === userId)) {
+            return res.status(403).send('No tienes permisos en este servidor');
+        }
+        const { categoryId } = req.body;
+        if (!categoryId) return res.status(400).send('Faltan datos');
+
+        this.framework.database.collection('guilds').updateOne(
+            { guild_id: guildId },
+            { $set: { callCategoryId: categoryId } },
+            { upsert: true }
+        ).catch(() => res.status(500).send('Error updating call category'));
+        res.redirect(`/panel/${guildId}/calls`);
+    }
+}

--- a/src/modules/calls/services/CallService.ts
+++ b/src/modules/calls/services/CallService.ts
@@ -1,0 +1,89 @@
+import { Client, TextChannel } from 'zumito-framework/discord';
+import { GuildDataGetter, ServiceContainer } from 'zumito-framework';
+
+interface ActiveCall {
+    guildA: string;
+    channelA: string;
+    guildB: string;
+    channelB: string;
+}
+
+export class CallService {
+    private client: Client;
+    private guildDataGetter: GuildDataGetter;
+    private pendingGuild: string | null = null;
+    private activeCalls: ActiveCall[] = [];
+
+    constructor() {
+        this.client = ServiceContainer.getService(Client);
+        this.guildDataGetter = ServiceContainer.getService(GuildDataGetter);
+        this.registerListener();
+    }
+
+    async requestCall(guildId: string): Promise<'waiting' | 'connected' | 'notConfigured'> {
+        const settings = await this.guildDataGetter.getGuildSettings(guildId);
+        if (!settings.callCategoryId) {
+            return 'notConfigured';
+        }
+
+        if (this.pendingGuild && this.pendingGuild !== guildId) {
+            const otherGuild = this.pendingGuild;
+            this.pendingGuild = null;
+            const result = await this.createChannels(guildId, otherGuild);
+            this.activeCalls.push({
+                guildA: guildId,
+                channelA: result.channelA.id,
+                guildB: otherGuild,
+                channelB: result.channelB.id
+            });
+            this.activeCalls.push({
+                guildA: otherGuild,
+                channelA: result.channelB.id,
+                guildB: guildId,
+                channelB: result.channelA.id
+            });
+            return 'connected';
+        }
+
+        this.pendingGuild = guildId;
+        return 'waiting';
+    }
+
+    private async createChannels(guildA: string, guildB: string): Promise<{ channelA: TextChannel; channelB: TextChannel; }> {
+        const [settingsA, settingsB] = await Promise.all([
+            this.guildDataGetter.getGuildSettings(guildA),
+            this.guildDataGetter.getGuildSettings(guildB)
+        ]);
+
+        const gA = this.client.guilds.cache.get(guildA);
+        const gB = this.client.guilds.cache.get(guildB);
+        if (!gA || !gB) {
+            throw new Error('Guild not found');
+        }
+        const catA = gA.channels.cache.get(settingsA.callCategoryId);
+        const catB = gB.channels.cache.get(settingsB.callCategoryId);
+
+        const channelA = await gA.channels.create({
+            name: `call-${gB.name}`,
+            type: 0,
+            parent: catA ? catA.id : null
+        });
+        const channelB = await gB.channels.create({
+            name: `call-${gA.name}`,
+            type: 0,
+            parent: catB ? catB.id : null
+        });
+        return { channelA, channelB };
+    }
+
+    private registerListener() {
+        this.client.on('messageCreate', async (message) => {
+            if (message.author.bot || !message.guild) return;
+            const call = this.activeCalls.find(c => c.channelA === message.channel.id);
+            if (!call) return;
+            const target = this.client.channels.cache.get(call.channelB) as TextChannel | undefined;
+            if (!target) return;
+            await target.send(`[${message.author.username}]: ${message.content}`);
+        });
+    }
+}

--- a/src/modules/calls/translations/command/call/en.json
+++ b/src/modules/calls/translations/command/call/en.json
@@ -1,0 +1,6 @@
+{
+    "description": "Connect with another server chat.",
+    "waiting": "Waiting for another server...",
+    "connected": "Call connected!",
+    "notConfigured": "Call category is not configured."
+}

--- a/src/modules/calls/translations/command/call/es.json
+++ b/src/modules/calls/translations/command/call/es.json
@@ -1,0 +1,6 @@
+{
+    "description": "Conecta con otro servidor en un chat.",
+    "waiting": "Esperando a otro servidor...",
+    "connected": "¡Llamada conectada!",
+    "notConfigured": "La categoría de llamadas no está configurada."
+}

--- a/src/modules/calls/views/calls-config.ejs
+++ b/src/modules/calls/views/calls-config.ejs
@@ -1,0 +1,40 @@
+<div class="card animate__animated animate__fadeIn">
+    <div class="flex items-center justify-between mb-6">
+        <h2 class="text-2xl font-bold text-discord-primary">Configurar Llamadas</h2>
+        <div class="p-2 bg-discord-primary/10 rounded-full">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 text-discord-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5h2l3 5v11h8V10l3-5h2" />
+            </svg>
+        </div>
+    </div>
+    <form method="POST" action="/panel/<%= guild.id %>/calls" class="space-y-6">
+        <div class="transition-all duration-200 hover:shadow-md p-4 rounded-lg bg-discord-dark-400/30">
+            <label class="flex items-center gap-2 mb-2 text-lg font-medium text-discord-white">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-discord-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5h2l3 5v11h8V10l3-5h2" />
+                </svg>
+                Categoría de Llamadas
+            </label>
+            <div class="relative">
+                <select name="categoryId" class="w-full bg-discord-dark-300 text-white pl-10 pr-4 py-3 rounded-lg border border-discord-dark-100 focus:border-discord-primary focus:ring focus:ring-discord-primary/20 focus:outline-none transition-all duration-200">
+                    <% categories.forEach(c => { %>
+                        <option value="<%= c.id %>" <%= guildSettings && guildSettings.callCategoryId === c.id ? 'selected' : '' %>><%= c.name %></option>
+                    <% }) %>
+                </select>
+                <div class="absolute left-3 top-1/2 transform -translate-y-1/2 text-discord-white/60">
+                    #
+                </div>
+            </div>
+            <p class="text-xs text-discord-white/60 mt-2">Selecciona la categoría donde se crearán los canales de llamadas</p>
+        </div>
+        <div class="flex justify-end pt-2">
+            <button type="submit" class="btn-primary flex items-center gap-2 px-6 py-3 shadow-lg hover:translate-y-[-2px] transition-all duration-200">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+                </svg>
+                Guardar Configuración
+            </button>
+        </div>
+    </form>
+</div>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/4.1.1/animate.min.css" />


### PR DESCRIPTION
## Summary
- create call module for cross-server text channels
- add `call` command and call service
- add user panel views and routes to configure call category
- provide translations for the new command

## Testing
- `npx eslint .` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*

------
https://chatgpt.com/codex/tasks/task_e_68821435f3fc832f9beb7ae8b52a1252