### PR TITLE
Add translations for confessions module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "sharp": "^0.33.4",
         "sodium-native": "^4.3.1",
         "zumito-db": "^1.0.1",
-        "zumito-framework": "^1.11.0"
+        "zumito-framework": "^1.11.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.9.0",
@@ -8102,9 +8102,9 @@
       }
     },
     "node_modules/zumito-framework": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/zumito-framework/-/zumito-framework-1.11.0.tgz",
-      "integrity": "sha512-C9k/oT44EtmonWdeXXpHqSATocqoYioXNailEgTu6k/6lkZ5BhiNBobsquYjMBrkX8DzW+iJbnY+Lze4YSiYsA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/zumito-framework/-/zumito-framework-1.11.1.tgz",
+      "integrity": "sha512-qh+IjidwPRo4K8FMUYpusUCzv7IUfFn3RdrJHswE7sA8gHXq8mAGBSMnjmhukn/d+Y2k9jIuNUsEYiCer6n3Aw==",
       "dependencies": {
         "@discordjs/rest": "^1.7.0",
         "@types/express": "^4.17.13",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "sharp": "^0.33.4",
     "sodium-native": "^4.3.1",
     "zumito-db": "^1.0.1",
-    "zumito-framework": "^1.11.0"
+    "zumito-framework": "^1.11.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",

--- a/src/modules/confessions/commands/confession.ts
+++ b/src/modules/confessions/commands/confession.ts
@@ -9,15 +9,15 @@ export class ConfessionCommand extends Command {
     botPermissions = ['VIEW_CHANNEL', 'SEND_MESSAGES'];
     type = CommandType.any;
 
-    async execute({ interaction }: CommandParameters): Promise<void> {
+    async execute({ interaction, trans }: CommandParameters): Promise<void> {
         if (!interaction) return;
         const modal = new ModalBuilder()
             .setCustomId(`${this.name}.send`)
-            .setTitle('Send Confession');
+            .setTitle(trans('modalTitle'));
 
         const input = new TextInputBuilder()
             .setCustomId('confession')
-            .setLabel('Your Confession')
+            .setLabel(trans('inputLabel'))
             .setStyle(TextInputStyle.Paragraph)
             .setRequired(true);
 
@@ -26,15 +26,15 @@ export class ConfessionCommand extends Command {
         await interaction.showModal(modal);
     }
 
-    async modalSubmit({ interaction, path }: ModalSubmitParameters): Promise<void> {
+    async modalSubmit({ interaction, path, trans }: ModalSubmitParameters): Promise<void> {
         if (path[1] !== 'send') return;
         const confession = interaction.fields.getTextInputValue('confession');
         const service = ServiceContainer.getService(ConfessionService) as ConfessionService;
         const success = await service.sendConfession(interaction.guild!.id, confession);
         if (!success) {
-            await interaction.reply({ content: 'Confession channel not configured.', flags: MessageFlags.Ephemeral });
+            await interaction.reply({ content: trans('notConfigured'), flags: MessageFlags.Ephemeral });
             return;
         }
-        await interaction.reply({ content: 'Your confession has been sent.', flags: MessageFlags.Ephemeral });
+        await interaction.reply({ content: trans('success'), flags: MessageFlags.Ephemeral });
     }
 }

--- a/src/modules/confessions/commands/confession.ts
+++ b/src/modules/confessions/commands/confession.ts
@@ -1,5 +1,5 @@
 import { ActionRowBuilder, ModalBuilder, TextInputBuilder, TextInputStyle, MessageFlags } from 'zumito-framework/discord';
-import { Command, CommandParameters, CommandType, ModalSubmitParameters, ServiceContainer } from 'zumito-framework';
+import { Command, CommandBinds, CommandParameters, CommandType, ModalSubmitParameters, ServiceContainer } from 'zumito-framework';
 import { ConfessionService } from '../services/ConfessionService.js';
 
 export class ConfessionCommand extends Command {
@@ -8,6 +8,9 @@ export class ConfessionCommand extends Command {
     categories = ['utils'];
     botPermissions = ['VIEW_CHANNEL', 'SEND_MESSAGES'];
     type = CommandType.any;
+    binds: CommandBinds = {
+        modalSubmit: this.modalSubmit, 
+    };
 
     async execute({ interaction, trans }: CommandParameters): Promise<void> {
         if (!interaction) return;

--- a/src/modules/confessions/services/ConfessionService.ts
+++ b/src/modules/confessions/services/ConfessionService.ts
@@ -1,19 +1,21 @@
 import { Client, EmbedBuilder, TextBasedChannel } from 'zumito-framework/discord';
-import { GuildDataGetter, ServiceContainer, ZumitoFramework } from 'zumito-framework';
+import { GuildDataGetter, ServiceContainer, TranslationManager } from 'zumito-framework';
 
 export class ConfessionService {
 
     constructor(
         private client: Client = ServiceContainer.getService(Client),
-        private guildDataGetter: GuildDataGetter = ServiceContainer.getService(GuildDataGetter), 
+        private guildDataGetter: GuildDataGetter = ServiceContainer.getService(GuildDataGetter),
+        private translator: TranslationManager = ServiceContainer.getService(TranslationManager),
     ) {}
 
     async sendConfession(guildId: string, text: string): Promise<boolean> {
         const guildSettings = await this.guildDataGetter.getGuildSettings(guildId);
+        const locale = guildSettings.lang || 'en';
         const channel = this.client.channels.cache.get(guildSettings.confessionsChannelId) as TextBasedChannel | undefined;
         if (!channel || !(channel as any).send) return false;
         const embed = new EmbedBuilder()
-            .setTitle('Un usuario ha enviado una confesión')
+            .setTitle(this.translator.get('confession.title', locale))
             .setDescription("```"+text+"```");
         await (channel as any).send({ 
             embeds: [embed],

--- a/src/modules/confessions/translations/command/confession/en.json
+++ b/src/modules/confessions/translations/command/confession/en.json
@@ -1,6 +1,7 @@
 {
-    "description": "Send an anonymous confession.",
-    "modalTitle": "Send Confession",
-    "success": "Your confession has been sent.",
-    "notConfigured": "Confession channel is not configured."
+  "description": "Send an anonymous confession.",
+  "modalTitle": "Send Confession",
+  "success": "Your confession has been sent.",
+  "notConfigured": "Confession channel is not configured.",
+  "inputLabel": "Your Confession"
 }

--- a/src/modules/confessions/translations/command/confession/es.json
+++ b/src/modules/confessions/translations/command/confession/es.json
@@ -1,6 +1,7 @@
 {
-    "description": "Envía una confesión anónima.",
-    "modalTitle": "Enviar Confesión",
-    "success": "Tu confesión ha sido enviada.",
-    "notConfigured": "El canal de confesiones no está configurado."
+  "description": "Envía una confesión anónima.",
+  "modalTitle": "Enviar Confesión",
+  "success": "Tu confesión ha sido enviada.",
+  "notConfigured": "El canal de confesiones no está configurado.",
+  "inputLabel": "Tu Confesión"
 }

--- a/src/modules/confessions/translations/confession/en.json
+++ b/src/modules/confessions/translations/confession/en.json
@@ -1,0 +1,3 @@
+{
+    "title": "A user has sent a confession."
+}

--- a/src/modules/confessions/translations/confession/es.json
+++ b/src/modules/confessions/translations/confession/es.json
@@ -1,0 +1,3 @@
+{
+    "title": "Un usuario ha enviado una confesión."
+}


### PR DESCRIPTION
## Summary
- add Spanish and English translation files for confessions embeds
- translate confession command modal and responses
- localize embed title via `TranslationManager`

## Testing
- `npx eslint .` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*

------
https://chatgpt.com/codex/tasks/task_e_68821fc39634832f86e68629cd4a28a8