### PR TITLE
Add music queue page

### DIFF
--- a/src/modules/music/index.ts
+++ b/src/modules/music/index.ts
@@ -1,11 +1,23 @@
 import { Client } from "discord.js";
 import { Module, ServiceContainer } from "zumito-framework";
+import { UserPanelNavigationService } from "@zumito-team/user-panel-module/services/UserPanelNavigationService";
 import { MusicService } from "./services/MusicService";
 
 export class MusicModule extends Module {
+    requeriments = {
+        services: ['UserPanelNavigationService'],
+    };
 
     constructor(modulePath: string) {
         super(modulePath);
-        ServiceContainer.addService(MusicService, [], true)
+        ServiceContainer.addService(MusicService, [], true);
+    }
+
+    async initialize(): Promise<void> {
+        await super.initialize();
+        const navigationService = ServiceContainer.getService(UserPanelNavigationService);
+        navigationService.registerSubItems('dashboard', 'general', [
+            { id: 'music', label: 'Music', url: '/panel/:guildId/music' },
+        ]);
     }
 }

--- a/src/modules/music/index.ts
+++ b/src/modules/music/index.ts
@@ -1,4 +1,3 @@
-import { Client } from "discord.js";
 import { Module, ServiceContainer } from "zumito-framework";
 import { UserPanelNavigationService } from "@zumito-team/user-panel-module/services/UserPanelNavigationService";
 import { MusicService } from "./services/MusicService";
@@ -17,7 +16,7 @@ export class MusicModule extends Module {
         await super.initialize();
         const navigationService = ServiceContainer.getService(UserPanelNavigationService);
         navigationService.registerSubItems('dashboard', 'general', [
-            { id: 'music', label: 'Music', url: '/panel/:guildId/music' },
+            { id: 'music', label: 'music.sidebarTitle', url: '/panel/:guildId/music' },
         ]);
     }
 }

--- a/src/modules/music/routes/UserPanelMusic.ts
+++ b/src/modules/music/routes/UserPanelMusic.ts
@@ -1,0 +1,50 @@
+import { Route, RouteMethod, ServiceContainer } from "zumito-framework";
+import { Client, PermissionFlagsBits } from "zumito-framework/discord";
+import { UserPanelAuthService } from "@zumito-team/user-panel-module/services/UserPanelAuthService";
+import { UserPanelViewService } from "@zumito-team/user-panel-module/services/UserPanelViewService";
+import { MusicService } from "../services/MusicService";
+import ejs from "ejs";
+import path, { dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export class UserPanelMusic extends Route {
+    method = RouteMethod.get;
+    path = '/panel/:guildId/music';
+
+    constructor(
+        private client: Client = ServiceContainer.getService(Client),
+        private auth = ServiceContainer.getService(UserPanelAuthService),
+    ) {
+        super();
+    }
+
+    async execute(req: any, res: any) {
+        const authData = await this.auth.isLoginValid(req);
+        if (!authData.isValid) return res.redirect('/panel/login');
+
+        const userId = authData.data.discordUserData.id;
+        const guildId = req.params.guildId as string;
+        const guild = this.client.guilds.cache.get(guildId);
+        if (!guild) return res.status(404).send('Servidor no encontrado');
+        let member = guild.members.cache.get(userId);
+        if (!member) member = await guild.members.fetch(userId).catch(() => null);
+        if (!member || !(member.permissions.has(PermissionFlagsBits.Administrator) ||
+            member.permissions.has(PermissionFlagsBits.ManageGuild) || guild.ownerId === userId)) {
+            return res.status(403).send('No tienes permisos en este servidor');
+        }
+
+        const musicService = ServiceContainer.getService(MusicService) as MusicService;
+        const queue = musicService.distube.getQueue(guildId);
+        const songs = queue?.songs.map((s, i) => ({ index: i, name: s.name })) ?? [];
+
+        const content = await ejs.renderFile(
+            path.resolve(__dirname, '../views/music-queue.ejs'),
+            { guild, songs },
+        );
+        const view = new UserPanelViewService();
+        const html = await view.render({ content, reqPath: req.path, req, res });
+        res.send(html);
+    }
+}

--- a/src/modules/music/routes/UserPanelMusic.ts
+++ b/src/modules/music/routes/UserPanelMusic.ts
@@ -2,6 +2,7 @@ import { Route, RouteMethod, ServiceContainer } from "zumito-framework";
 import { Client, PermissionFlagsBits } from "zumito-framework/discord";
 import { UserPanelAuthService } from "@zumito-team/user-panel-module/services/UserPanelAuthService";
 import { UserPanelViewService } from "@zumito-team/user-panel-module/services/UserPanelViewService";
+import { UserPanelLanguageManager } from "@zumito-team/user-panel-module/services/UserPanelLanguageManager";
 import { MusicService } from "../services/MusicService";
 import ejs from "ejs";
 import path, { dirname } from "path";
@@ -16,6 +17,7 @@ export class UserPanelMusic extends Route {
     constructor(
         private client: Client = ServiceContainer.getService(Client),
         private auth = ServiceContainer.getService(UserPanelAuthService),
+        private userPanelLanguageManager = ServiceContainer.getService(UserPanelLanguageManager),
     ) {
         super();
     }
@@ -41,7 +43,7 @@ export class UserPanelMusic extends Route {
 
         const content = await ejs.renderFile(
             path.resolve(__dirname, '../views/music-queue.ejs'),
-            { guild, songs },
+            { guild, songs, ...this.userPanelLanguageManager.getLanguageVariables(req, res) },
         );
         const view = new UserPanelViewService();
         const html = await view.render({ content, reqPath: req.path, req, res });

--- a/src/modules/music/translations/en.json
+++ b/src/modules/music/translations/en.json
@@ -39,5 +39,10 @@
     "lyrics": {
       "description": "Show the lyrics of the current song."
     }
+  },
+  "music": {
+    "sidebarTitle": "Music",
+    "queueTitle": "Music Queue",
+    "queueEmpty": "The queue is empty."
   }
 }

--- a/src/modules/music/translations/es.json
+++ b/src/modules/music/translations/es.json
@@ -39,5 +39,10 @@
     "lyrics": {
       "description": "Muestra la letra de la canción actual."
     }
+  },
+  "music": {
+    "sidebarTitle": "Música",
+    "queueTitle": "Cola de Reproducción",
+    "queueEmpty": "La cola está vacía."
   }
 }

--- a/src/modules/music/views/music-queue.ejs
+++ b/src/modules/music/views/music-queue.ejs
@@ -1,7 +1,7 @@
 <div class="card">
-    <h2 class="text-xl font-bold mb-4">Cola de Reproducción</h2>
+    <h2 class="text-xl font-bold mb-4"><%= t('music.queueTitle') %></h2>
     <% if (songs.length === 0) { %>
-        <p>La cola está vacía.</p>
+        <p><%= t('music.queueEmpty') %></p>
     <% } else { %>
         <ol class="list-decimal ml-4 space-y-1">
             <% songs.forEach(song => { %>

--- a/src/modules/music/views/music-queue.ejs
+++ b/src/modules/music/views/music-queue.ejs
@@ -1,0 +1,15 @@
+<div class="card">
+    <h2 class="text-xl font-bold mb-4">Cola de Reproducción</h2>
+    <% if (songs.length === 0) { %>
+        <p>La cola está vacía.</p>
+    <% } else { %>
+        <ol class="list-decimal ml-4 space-y-1">
+            <% songs.forEach(song => { %>
+                <li>
+                    <% if (song.index === 0) { %>▶️ <% } else { %><%= song.index %>. <% } %>
+                    <%= song.name %>
+                </li>
+            <% }) %>
+        </ol>
+    <% } %>
+</div>


### PR DESCRIPTION
## Summary
- add user panel page to display music queue
- register music page in user panel navigation

## Testing
- `npx eslint .` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*

------
https://chatgpt.com/codex/tasks/task_e_6882302755cc832fb10be46bbb99b78f