### PR TITLE
Add admin configurable landing theme

### DIFF
--- a/src/modules/landing/index.ts
+++ b/src/modules/landing/index.ts
@@ -1,5 +1,6 @@
 import { Module, ServiceContainer } from "zumito-framework";
 import { NavigationService } from "@zumito-team/admin-module/services/NavigationService.js";
+import { LandingViewService } from "./services/LandingViewService";
 
 export class LandingModule extends Module {
     requeriments = {
@@ -8,6 +9,7 @@ export class LandingModule extends Module {
 
     constructor(modulePath: string) {
         super(modulePath);
+        ServiceContainer.addService(LandingViewService, [], true);
     }
 
     async initialize(): Promise<void> {

--- a/src/modules/landing/index.ts
+++ b/src/modules/landing/index.ts
@@ -30,6 +30,7 @@ export class LandingModule extends Module {
                             items: [ 
                                 { label: 'Modules', url: '/admin/landing/modules' },
                                 { label: 'Featured Commands', url: '/admin/landing/featured-commands' },
+                                { label: 'Theme', url: '/admin/landing/theme' },
                             ],
                         },
                     ],

--- a/src/modules/landing/routes/AdminTheme.ts
+++ b/src/modules/landing/routes/AdminTheme.ts
@@ -1,0 +1,38 @@
+import { Route, RouteMethod, ServiceContainer, ZumitoFramework } from "zumito-framework";
+import { AdminAuthService } from "@zumito-team/admin-module/services/AdminAuthService";
+import { AdminViewService } from "@zumito-team/admin-module/services/AdminViewService";
+import { LandingViewService } from "../services/LandingViewService";
+import ejs from "ejs";
+import path, { dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export class AdminTheme extends Route {
+    method = RouteMethod.get;
+    path = '/admin/landing/theme';
+
+    constructor(
+        private framework: ZumitoFramework = ServiceContainer.getService(ZumitoFramework),
+        private adminAuthService: AdminAuthService = ServiceContainer.getService(AdminAuthService),
+        private adminViewService: AdminViewService = ServiceContainer.getService(AdminViewService),
+    ) {
+        super();
+    }
+
+    async execute(req: any, res: any) {
+        if (!this.adminAuthService.isLoginValid(req)) {
+            return;
+        }
+
+        const theme = await LandingViewService.getTheme();
+        const content = await this.adminViewService.render({
+            title: 'Landing Theme',
+            content: await ejs.renderFile(path.resolve(__dirname, '../views/admin_theme.ejs'), { theme }),
+            reqPath: this.path,
+            user: req.user || { name: 'Admin' }
+        });
+
+        res.send(content);
+    }
+}

--- a/src/modules/landing/routes/AdminTheme.ts
+++ b/src/modules/landing/routes/AdminTheme.ts
@@ -16,6 +16,7 @@ export class AdminTheme extends Route {
         private framework: ZumitoFramework = ServiceContainer.getService(ZumitoFramework),
         private adminAuthService: AdminAuthService = ServiceContainer.getService(AdminAuthService),
         private adminViewService: AdminViewService = ServiceContainer.getService(AdminViewService),
+        private landingViewService: LandingViewService = ServiceContainer.getService(LandingViewService),
     ) {
         super();
     }
@@ -25,7 +26,7 @@ export class AdminTheme extends Route {
             return;
         }
 
-        const theme = await LandingViewService.getTheme();
+        const theme = await this.landingViewService.getTheme();
         const content = await this.adminViewService.render({
             title: 'Landing Theme',
             content: await ejs.renderFile(path.resolve(__dirname, '../views/admin_theme.ejs'), { theme }),

--- a/src/modules/landing/routes/AdminThemePost.ts
+++ b/src/modules/landing/routes/AdminThemePost.ts
@@ -1,0 +1,32 @@
+import { Route, RouteMethod, ServiceContainer, ZumitoFramework } from "zumito-framework";
+import { AdminAuthService } from "@zumito-team/admin-module/services/AdminAuthService";
+
+export class AdminThemePost extends Route {
+    method = RouteMethod.post;
+    path = '/admin/landing/theme';
+
+    constructor(
+        private framework: ZumitoFramework = ServiceContainer.getService(ZumitoFramework),
+        private adminAuthService: AdminAuthService = ServiceContainer.getService(AdminAuthService),
+    ) {
+        super();
+    }
+
+    async execute(req: any, res: any) {
+        if (!this.adminAuthService.isLoginValid(req)) return res.status(400).json({ message: 'Access Denied' });
+
+        const allowed = ['primary','secondary','accent','gradientFrom','gradientVia','gradientTo','textMain','textSecondary','background'];
+        const data: Record<string, string> = {};
+        for (const key of allowed) {
+            if (req.body && req.body[key]) data[key] = req.body[key];
+        }
+
+        await this.framework.database.collection('landingtheme').updateOne(
+            { id: 'default' },
+            { $set: data },
+            { upsert: true }
+        );
+
+        res.status(200).json({ message: 'Theme saved successfully.' });
+    }
+}

--- a/src/modules/landing/routes/AdminThemePost.ts
+++ b/src/modules/landing/routes/AdminThemePost.ts
@@ -1,5 +1,6 @@
 import { Route, RouteMethod, ServiceContainer, ZumitoFramework } from "zumito-framework";
 import { AdminAuthService } from "@zumito-team/admin-module/services/AdminAuthService";
+import { LandingViewService } from "../services/LandingViewService";
 
 export class AdminThemePost extends Route {
     method = RouteMethod.post;
@@ -8,6 +9,7 @@ export class AdminThemePost extends Route {
     constructor(
         private framework: ZumitoFramework = ServiceContainer.getService(ZumitoFramework),
         private adminAuthService: AdminAuthService = ServiceContainer.getService(AdminAuthService),
+        private landingViewService: LandingViewService = ServiceContainer.getService(LandingViewService),
     ) {
         super();
     }
@@ -26,6 +28,7 @@ export class AdminThemePost extends Route {
             { $set: data },
             { upsert: true }
         );
+        await this.landingViewService.getTheme(true); // Force reload theme cache
 
         res.status(200).json({ message: 'Theme saved successfully.' });
     }

--- a/src/modules/landing/routes/Commands.ts
+++ b/src/modules/landing/routes/Commands.ts
@@ -30,7 +30,7 @@ export class Commands extends Route {
             }
         }
         // Obtener el theme para el layout
-        const theme = LandingViewService.getTheme();
+        const theme = await LandingViewService.getTheme();
         // Renderizar la vista
         const content = await ejs.renderFile(
             path.join(__dirname, "../views/commands.ejs"),

--- a/src/modules/landing/routes/Commands.ts
+++ b/src/modules/landing/routes/Commands.ts
@@ -13,7 +13,9 @@ export class Commands extends Route {
 
     framework: ZumitoFramework;
 
-    constructor() {
+    constructor(
+        private landingViewService: LandingViewService = ServiceContainer.getService(LandingViewService),
+    ) {
         super();
         this.framework = ServiceContainer.getService(ZumitoFramework);
     }
@@ -30,7 +32,7 @@ export class Commands extends Route {
             }
         }
         // Obtener el theme para el layout
-        const theme = await LandingViewService.getTheme();
+        const theme = await this.landingViewService.getTheme();
         // Renderizar la vista
         const content = await ejs.renderFile(
             path.join(__dirname, "../views/commands.ejs"),
@@ -39,8 +41,7 @@ export class Commands extends Route {
                 theme
             }
         );
-        const landingView = new LandingViewService();
-        const html = await landingView.render({
+        const html = await this.landingViewService.render({
             title: "Comandos",
             content,
             extra: { theme }

--- a/src/modules/landing/routes/Landing.ts
+++ b/src/modules/landing/routes/Landing.ts
@@ -18,6 +18,7 @@ export class Landing extends Route {
     constructor(
         private framework: ZumitoFramework = ServiceContainer.getService(ZumitoFramework),
         private translationService: TranslationManager = ServiceContainer.getService(TranslationManager),
+        private landingViewService: LandingViewService = ServiceContainer.getService(LandingViewService),
     ) {
         super();
         this.client = ServiceContainer.getService(Client);
@@ -75,7 +76,7 @@ export class Landing extends Route {
         ];
 
         // Configuración de colores y estilos (puede venir de config o env)
-        const theme = await LandingViewService.getTheme();
+        const theme = await this.landingViewService.getTheme();
 
         const content = await ejs.renderFile(
             path.join(__dirname, "../views/landing.ejs"),
@@ -100,8 +101,7 @@ export class Landing extends Route {
             }
         );
 
-        const landingView = new LandingViewService();
-        const html = await landingView.render({
+        const html = await this.landingViewService.render({
             title: "Inicio",
             content,
             extra: { theme }

--- a/src/modules/landing/routes/Landing.ts
+++ b/src/modules/landing/routes/Landing.ts
@@ -75,7 +75,7 @@ export class Landing extends Route {
         ];
 
         // Configuración de colores y estilos (puede venir de config o env)
-        const theme = LandingViewService.getTheme();
+        const theme = await LandingViewService.getTheme();
 
         const content = await ejs.renderFile(
             path.join(__dirname, "../views/landing.ejs"),

--- a/src/modules/landing/services/LandingViewService.ts
+++ b/src/modules/landing/services/LandingViewService.ts
@@ -1,8 +1,21 @@
 import ejs from "ejs";
 import path, { dirname } from "path";
 import { fileURLToPath } from "url";
+import { ServiceContainer, ZumitoFramework } from "zumito-framework";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export const DEFAULT_THEME = {
+    primary: '#5865F2',
+    secondary: '#36393f',
+    accent: '#57F287',
+    gradientFrom: '#23272A',
+    gradientVia: '#36393f',
+    gradientTo: '#5865F2',
+    textMain: '#fff',
+    textSecondary: '#fgf',
+    background: '#1e2124'
+};
 
 export class LandingViewService {
     private static layoutPath = path.resolve(__dirname, '../views/layouts/landing.ejs');
@@ -22,7 +35,7 @@ export class LandingViewService {
                 title,
                 content,
                 ...extra,
-                theme: (extra && extra.theme) || LandingViewService.getTheme()
+                theme: (extra && extra.theme) || await LandingViewService.getTheme()
             }
         );
     }
@@ -41,17 +54,23 @@ export class LandingViewService {
         };
     } */
 
-    static getTheme() {
+    static async getTheme() {
+        const framework = ServiceContainer.hasService(ZumitoFramework) ? ServiceContainer.getService(ZumitoFramework) : null;
+        let data: any = null;
+        if (framework) {
+            data = await framework.database.collection('landingtheme').findOne({ id: 'default' }).catch(() => null);
+        }
+
         return {
-            primary: process.env.LANDING_PRIMARY_COLOR || '#e11d48',         // rose-600
-            secondary: process.env.LANDING_SECONDARY_COLOR || '#a78bfa',     // purple-400
-            accent: process.env.LANDING_ACCENT_COLOR || '#f472b6',           // pink-400
-            gradientFrom: process.env.LANDING_GRADIENT_FROM || '#e11d48',    // rose-600
-            gradientVia: process.env.LANDING_GRADIENT_VIA || '#f472b6',      // pink-400
-            gradientTo: process.env.LANDING_GRADIENT_TO || '#7dd3fc',        // sky-300
-            textMain: process.env.LANDING_TEXT_MAIN || '#222',
-            textSecondary: process.env.LANDING_TEXT_SECONDARY || '#444',
-            background: process.env.LANDING_BACKGROUND || '#fff', // white
+            primary: data?.primary || process.env.LANDING_PRIMARY_COLOR || '#e11d48',
+            secondary: data?.secondary || process.env.LANDING_SECONDARY_COLOR || '#a78bfa',
+            accent: data?.accent || process.env.LANDING_ACCENT_COLOR || '#f472b6',
+            gradientFrom: data?.gradientFrom || process.env.LANDING_GRADIENT_FROM || '#e11d48',
+            gradientVia: data?.gradientVia || process.env.LANDING_GRADIENT_VIA || '#f472b6',
+            gradientTo: data?.gradientTo || process.env.LANDING_GRADIENT_TO || '#7dd3fc',
+            textMain: data?.textMain || process.env.LANDING_TEXT_MAIN || '#222',
+            textSecondary: data?.textSecondary || process.env.LANDING_TEXT_SECONDARY || '#444',
+            background: data?.background || process.env.LANDING_BACKGROUND || '#fff',
         };
     }
 }

--- a/src/modules/landing/services/LandingViewService.ts
+++ b/src/modules/landing/services/LandingViewService.ts
@@ -19,6 +19,7 @@ export const DEFAULT_THEME = {
 
 export class LandingViewService {
     private static layoutPath = path.resolve(__dirname, '../views/layouts/landing.ejs');
+    private theme: any;
 
     async render({
         title,
@@ -35,7 +36,7 @@ export class LandingViewService {
                 title,
                 content,
                 ...extra,
-                theme: (extra && extra.theme) || await LandingViewService.getTheme()
+                theme: (extra && extra.theme) || await this.getTheme()
             }
         );
     }
@@ -54,14 +55,32 @@ export class LandingViewService {
         };
     } */
 
-    static async getTheme() {
+    async getTheme(forceReload = false) {
+        if (this.theme && !forceReload) return this.theme;
         const framework = ServiceContainer.hasService(ZumitoFramework) ? ServiceContainer.getService(ZumitoFramework) : null;
         let data: any = null;
         if (framework) {
             data = await framework.database.collection('landingtheme').findOne({ id: 'default' }).catch(() => null);
         }
 
-        return {
+        this.theme = {
+            primary: data?.primary || process.env.LANDING_PRIMARY_COLOR || '#5865F2',
+            secondary: data?.secondary || process.env.LANDING_SECONDARY_COLOR || '#36393f',
+            accent: data?.accent || process.env.LANDING_ACCENT_COLOR || '#57F287',
+            gradientFrom: data?.gradientFrom || process.env.LANDING_GRADIENT_FROM || '#23272A',
+            gradientVia: data?.gradientVia || process.env.LANDING_GRADIENT_VIA || '#36393f',
+            gradientTo: data?.gradientTo || process.env.LANDING_GRADIENT_TO || '#5865F2',
+            textMain: data?.textMain || process.env.LANDING_TEXT_MAIN || '#fff',
+            textSecondary: data?.textSecondary || process.env.LANDING_TEXT_SECONDARY || '#fgf',
+            background: data?.background || process.env.LANDING_BACKGROUND || '#1e2124',
+        };
+        return this.theme;
+    }
+}
+
+/*
+
+return {
             primary: data?.primary || process.env.LANDING_PRIMARY_COLOR || '#e11d48',
             secondary: data?.secondary || process.env.LANDING_SECONDARY_COLOR || '#a78bfa',
             accent: data?.accent || process.env.LANDING_ACCENT_COLOR || '#f472b6',
@@ -72,5 +91,4 @@ export class LandingViewService {
             textSecondary: data?.textSecondary || process.env.LANDING_TEXT_SECONDARY || '#444',
             background: data?.background || process.env.LANDING_BACKGROUND || '#fff',
         };
-    }
-}
+        */

--- a/src/modules/landing/views/admin_theme.ejs
+++ b/src/modules/landing/views/admin_theme.ejs
@@ -1,0 +1,63 @@
+<div class="card mt-6">
+    <div class="flex items-center justify-between mb-4">
+        <div class="text-lg font-semibold">Landing Theme</div>
+    </div>
+    <form id="themeForm" class="space-y-4">
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+                <label class="block mb-1">Primary</label>
+                <input type="color" name="primary" value="<%= theme.primary %>" class="w-full h-10 bg-discord-dark-300 rounded" />
+            </div>
+            <div>
+                <label class="block mb-1">Secondary</label>
+                <input type="color" name="secondary" value="<%= theme.secondary %>" class="w-full h-10 bg-discord-dark-300 rounded" />
+            </div>
+            <div>
+                <label class="block mb-1">Accent</label>
+                <input type="color" name="accent" value="<%= theme.accent %>" class="w-full h-10 bg-discord-dark-300 rounded" />
+            </div>
+            <div>
+                <label class="block mb-1">Gradient From</label>
+                <input type="color" name="gradientFrom" value="<%= theme.gradientFrom %>" class="w-full h-10 bg-discord-dark-300 rounded" />
+            </div>
+            <div>
+                <label class="block mb-1">Gradient Via</label>
+                <input type="color" name="gradientVia" value="<%= theme.gradientVia %>" class="w-full h-10 bg-discord-dark-300 rounded" />
+            </div>
+            <div>
+                <label class="block mb-1">Gradient To</label>
+                <input type="color" name="gradientTo" value="<%= theme.gradientTo %>" class="w-full h-10 bg-discord-dark-300 rounded" />
+            </div>
+            <div>
+                <label class="block mb-1">Text Main</label>
+                <input type="color" name="textMain" value="<%= theme.textMain %>" class="w-full h-10 bg-discord-dark-300 rounded" />
+            </div>
+            <div>
+                <label class="block mb-1">Text Secondary</label>
+                <input type="color" name="textSecondary" value="<%= theme.textSecondary %>" class="w-full h-10 bg-discord-dark-300 rounded" />
+            </div>
+            <div>
+                <label class="block mb-1">Background</label>
+                <input type="color" name="background" value="<%= theme.background %>" class="w-full h-10 bg-discord-dark-300 rounded" />
+            </div>
+        </div>
+        <div class="flex justify-end">
+            <button type="submit" class="btn-primary">Save</button>
+        </div>
+    </form>
+</div>
+<script>
+    document.getElementById('themeForm').addEventListener('submit', async e => {
+        e.preventDefault();
+        const formData = new FormData(e.target);
+        const data = Object.fromEntries(formData.entries());
+        const res = await fetch('/admin/landing/theme', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(data)
+        });
+        if (res.ok) {
+            window.location.reload();
+        }
+    });
+</script>


### PR DESCRIPTION
## Summary
- allow editing landing page theme from admin panel
- use async theme loading with database fallback
- extend landing navigation menu

## Testing
- `npx eslint .` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*

------
https://chatgpt.com/codex/tasks/task_e_68823bbaec48832f921adc9d3729bd8b