### PR TITLE
Add theme import/export routes

### DIFF
--- a/src/modules/landing/routes/AdminThemeExport.ts
+++ b/src/modules/landing/routes/AdminThemeExport.ts
@@ -1,0 +1,24 @@
+import { Route, RouteMethod, ServiceContainer, ZumitoFramework } from "zumito-framework";
+import { AdminAuthService } from "@zumito-team/admin-module/services/AdminAuthService";
+import { LandingViewService } from "../services/LandingViewService";
+
+export class AdminThemeExport extends Route {
+    method = RouteMethod.get;
+    path = '/admin/landing/theme/export';
+
+    constructor(
+        private framework: ZumitoFramework = ServiceContainer.getService(ZumitoFramework),
+        private adminAuthService: AdminAuthService = ServiceContainer.getService(AdminAuthService),
+        private landingViewService: LandingViewService = ServiceContainer.getService(LandingViewService),
+    ) {
+        super();
+    }
+
+    async execute(req: any, res: any) {
+        if (!this.adminAuthService.isLoginValid(req)) return res.status(400).json({ message: 'Access Denied' });
+
+        const theme = await this.landingViewService.getTheme();
+        res.setHeader('Content-Type', 'application/json');
+        res.send(JSON.stringify(theme));
+    }
+}

--- a/src/modules/landing/routes/AdminThemeImport.ts
+++ b/src/modules/landing/routes/AdminThemeImport.ts
@@ -1,0 +1,35 @@
+import { Route, RouteMethod, ServiceContainer, ZumitoFramework } from "zumito-framework";
+import { AdminAuthService } from "@zumito-team/admin-module/services/AdminAuthService";
+import { LandingViewService } from "../services/LandingViewService";
+
+export class AdminThemeImport extends Route {
+    method = RouteMethod.post;
+    path = '/admin/landing/theme/import';
+
+    constructor(
+        private framework: ZumitoFramework = ServiceContainer.getService(ZumitoFramework),
+        private adminAuthService: AdminAuthService = ServiceContainer.getService(AdminAuthService),
+        private landingViewService: LandingViewService = ServiceContainer.getService(LandingViewService),
+    ) {
+        super();
+    }
+
+    async execute(req: any, res: any) {
+        if (!this.adminAuthService.isLoginValid(req)) return res.status(400).json({ message: 'Access Denied' });
+
+        const allowed = ['primary','secondary','accent','gradientFrom','gradientVia','gradientTo','textMain','textSecondary','background'];
+        const data: Record<string, string> = {};
+        for (const key of allowed) {
+            if (req.body && req.body[key]) data[key] = req.body[key];
+        }
+
+        await this.framework.database.collection('landingtheme').updateOne(
+            { id: 'default' },
+            { $set: data },
+            { upsert: true }
+        );
+        await this.landingViewService.getTheme(true);
+
+        res.status(200).json({ message: 'Theme imported successfully.' });
+    }
+}

--- a/src/modules/landing/views/admin_theme.ejs
+++ b/src/modules/landing/views/admin_theme.ejs
@@ -41,7 +41,12 @@
                 <input type="color" name="background" value="<%= theme.background %>" class="w-full h-10 bg-discord-dark-300 rounded" />
             </div>
         </div>
-        <div class="flex justify-end">
+        <div class="flex flex-wrap justify-between items-center gap-2">
+            <div class="flex items-center gap-2">
+                <input type="file" id="importFile" accept=".json" class="hidden" />
+                <button type="button" id="importButton" class="btn-secondary">Import</button>
+                <button type="button" id="exportButton" class="btn-secondary">Export</button>
+            </div>
             <button type="submit" class="btn-primary">Save</button>
         </div>
     </form>
@@ -59,5 +64,38 @@
         if (res.ok) {
             window.location.reload();
         }
+    });
+    document.getElementById('importButton').addEventListener('click', () => {
+        document.getElementById('importFile').click();
+    });
+    document.getElementById('importFile').addEventListener('change', async e => {
+        const file = e.target.files[0];
+        if (!file) return;
+        const text = await file.text();
+        try {
+            const data = JSON.parse(text);
+            const res = await fetch('/admin/landing/theme/import', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(data)
+            });
+            if (res.ok) window.location.reload();
+        } catch {
+            console.error('Invalid theme file');
+        }
+    });
+    document.getElementById('exportButton').addEventListener('click', async () => {
+        const res = await fetch('/admin/landing/theme/export');
+        if (!res.ok) return;
+        const data = await res.json();
+        const blob = new Blob([JSON.stringify(data, null, 4)], { type: 'application/json' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'theme.json';
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
+        URL.revokeObjectURL(url);
     });
 </script>


### PR DESCRIPTION
## Summary
- add routes to export and import landing theme
- update Admin Theme page to allow importing and exporting JSON

## Testing
- `npx eslint .` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*
- `npm install` *(fails: node-canvas build error due to missing pixman-1)*

------
https://chatgpt.com/codex/tasks/task_e_688246203460832fa7e3d577926d70a3