### PR TITLE
Add configurable navbar to landing module

### DIFF
--- a/src/modules/landing/definitions/defaultNavbarLinks.ts
+++ b/src/modules/landing/definitions/defaultNavbarLinks.ts
@@ -1,0 +1,4 @@
+export const DEFAULT_NAVBAR_LINKS = [
+    { label: 'Home', url: '/', order: 1 },
+    { label: 'Commands', url: '/commands', order: 2 }
+];

--- a/src/modules/landing/index.ts
+++ b/src/modules/landing/index.ts
@@ -33,6 +33,7 @@ export class LandingModule extends Module {
                                 { label: 'Modules', url: '/admin/landing/modules' },
                                 { label: 'Featured Commands', url: '/admin/landing/featured-commands' },
                                 { label: 'Theme', url: '/admin/landing/theme' },
+                                { label: 'Navbar', url: '/admin/landing/navbar' },
                             ],
                         },
                     ],

--- a/src/modules/landing/routes/AdminNavbar.ts
+++ b/src/modules/landing/routes/AdminNavbar.ts
@@ -1,0 +1,49 @@
+import { Route, RouteMethod, ServiceContainer, ZumitoFramework } from "zumito-framework";
+import { AdminViewService } from "@zumito-team/admin-module/services/AdminViewService";
+import { AdminAuthService } from "@zumito-team/admin-module/services/AdminAuthService";
+import { DEFAULT_NAVBAR_LINKS } from "../definitions/defaultNavbarLinks";
+import ejs from "ejs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+export class AdminNavbar extends Route {
+    method = RouteMethod.get;
+    path = '/admin/landing/navbar';
+
+    constructor(
+        private framework: ZumitoFramework = ServiceContainer.getService(ZumitoFramework),
+        private adminAuthService: AdminAuthService = ServiceContainer.getService(AdminAuthService),
+        private adminViewService: AdminViewService = ServiceContainer.getService(AdminViewService),
+    ) {
+        super();
+    }
+
+    async execute(req: any, res: any) {
+        if (!this.adminAuthService.isLoginValid(req)) {
+            return;
+        }
+
+        const collection = this.framework.database.collection('landingnavbar');
+        let links = await collection.find().sort({ order: 1 }).toArray();
+        if (links.length === 0) {
+            await collection.insertMany(DEFAULT_NAVBAR_LINKS);
+            links = DEFAULT_NAVBAR_LINKS;
+        }
+
+        const routes = (this.framework.routes || []).filter((r: any) => {
+            return r.method !== RouteMethod.post && !r.path.includes(':');
+        }).map((r: any) => r.path);
+
+        const content = await this.adminViewService.render({
+            title: 'Navbar',
+            content: await ejs.renderFile(path.resolve(__dirname, '../views/admin_navbar.ejs'), { links, routes }),
+            reqPath: this.path,
+            user: req.user || { name: 'Admin' }
+        });
+
+        res.send(content);
+    }
+}

--- a/src/modules/landing/routes/AdminNavbarPost.ts
+++ b/src/modules/landing/routes/AdminNavbarPost.ts
@@ -1,0 +1,38 @@
+import { Route, RouteMethod, ServiceContainer, ZumitoFramework } from "zumito-framework";
+import { AdminAuthService } from "@zumito-team/admin-module/services/AdminAuthService";
+
+export class AdminNavbarPost extends Route {
+    method = RouteMethod.post;
+    path = '/admin/landing/navbar';
+
+    constructor(
+        private framework: ZumitoFramework = ServiceContainer.getService(ZumitoFramework),
+        private adminAuthService: AdminAuthService = ServiceContainer.getService(AdminAuthService),
+    ) {
+        super();
+    }
+
+    async execute(req: any, res: any) {
+        if (!this.adminAuthService.isLoginValid(req)) return res.status(400).json({ message: 'Access Denied' });
+
+        const links = req.body.links;
+        if (!Array.isArray(links)) return res.status(400).json({ message: 'Invalid data.' });
+
+        const collection = this.framework.database.collection('landingnavbar');
+        const existing = await collection.find().toArray();
+        const labels = links.map(l => l.label);
+        for (const link of links) {
+            await collection.updateOne(
+                { label: link.label },
+                { $set: { url: link.url, order: parseInt(link.order) } },
+                { upsert: true }
+            );
+        }
+        for (const link of existing) {
+            if (!labels.includes(link.label)) {
+                await collection.deleteOne({ label: link.label });
+            }
+        }
+        res.status(200).json({ message: 'Navbar saved.' });
+    }
+}

--- a/src/modules/landing/routes/Landing.ts
+++ b/src/modules/landing/routes/Landing.ts
@@ -5,6 +5,7 @@ import ejs from 'ejs';
 import { Client, version as discordjsVersion } from "zumito-framework/discord";
 import { LandingViewService } from "../services/LandingViewService";
 import { DEFAULT_LANDING_MODULES } from "../definitions/defaultLandingModules";
+import { DEFAULT_NAVBAR_LINKS } from "../definitions/defaultNavbarLinks";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -53,6 +54,13 @@ export class Landing extends Route {
         if (modules.length === 0) {
             await collection.insertMany(DEFAULT_LANDING_MODULES);
             modules = DEFAULT_LANDING_MODULES.filter(m => m.enabled);
+        }
+
+        const navCollection = this.framework.database.collection('landingnavbar');
+        let navLinks = await navCollection.find().sort({ order: 1 }).toArray();
+        if (navLinks.length === 0) {
+            await navCollection.insertMany(DEFAULT_NAVBAR_LINKS);
+            navLinks = DEFAULT_NAVBAR_LINKS;
         }
         
         // FAQs (pueden venir de config, aquí ejemplo hardcode)
@@ -104,7 +112,7 @@ export class Landing extends Route {
         const html = await this.landingViewService.render({
             title: "Inicio",
             content,
-            extra: { theme }
+            extra: { theme, navLinks, botName }
         });
         res.send(html);
     }

--- a/src/modules/landing/views/admin_navbar.ejs
+++ b/src/modules/landing/views/admin_navbar.ejs
@@ -1,0 +1,120 @@
+<div class="card mt-6" x-data="{ links: <%- JSON.stringify(links) %> }">
+  <div class="flex items-center justify-between mb-4">
+    <div class="text-lg font-semibold">Navbar Links</div>
+    <button type="button" id="addLink" class="btn-secondary">Add</button>
+  </div>
+  <form id="linksForm" class="space-y-4">
+    <table class="w-full text-sm">
+      <thead>
+        <tr class="bg-discord-dark-300">
+          <th class="text-left p-3">Label</th>
+          <th class="text-left p-3">Route</th>
+          <th class="text-left p-3 w-32">Order</th>
+          <th class="p-3 w-12"></th>
+        </tr>
+      </thead>
+      <tbody id="linksBody">
+        <% links.forEach(function(link, index) { %>
+          <tr class="border-t border-discord-dark-400">
+            <td class="p-3 flex items-center gap-2">
+              <span class="cursor-move handle">⇅</span>
+              <input type="text" name="links[<%= index %>][label]" value="<%= link.label %>" class="w-32 px-2 py-1 rounded bg-discord-dark-300 text-white" />
+            </td>
+            <td class="p-3">
+              <select name="links[<%= index %>][url]" class="px-2 py-1 rounded bg-discord-dark-300 text-white">
+                <% routes.forEach(function(r){ %>
+                  <option value="<%= r %>" <%= r === link.url ? 'selected' : '' %>><%= r %></option>
+                <% }) %>
+              </select>
+            </td>
+            <td class="p-3">
+              <input type="number" name="links[<%= index %>][order]" value="<%= link.order %>" min="1" class="w-20 px-2 py-1 rounded bg-discord-dark-300 text-white" />
+            </td>
+            <td class="p-3 text-right">
+              <button type="button" class="deleteLink text-red-400">Delete</button>
+            </td>
+          </tr>
+        <% }) %>
+      </tbody>
+    </table>
+    <div class="flex justify-end">
+      <button type="submit" class="btn-primary">Save</button>
+    </div>
+  </form>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
+<script>
+  const tbody = document.getElementById('linksBody');
+  const addButton = document.getElementById('addLink');
+  new Sortable(tbody, {
+    handle: '.handle',
+    animation: 150,
+    onEnd: updateOrders
+  });
+
+  addButton.addEventListener('click', () => {
+    const index = tbody.querySelectorAll('tr').length;
+    const row = document.createElement('tr');
+    row.className = 'border-t border-discord-dark-400';
+    row.innerHTML = `
+      <td class="p-3 flex items-center gap-2">
+        <span class="cursor-move handle">⇅</span>
+        <input type="text" name="links[${index}][label]" class="w-32 px-2 py-1 rounded bg-discord-dark-300 text-white" required />
+      </td>
+      <td class="p-3">
+        <select name="links[${index}][url]" class="px-2 py-1 rounded bg-discord-dark-300 text-white">
+          ${routes.map(r => `<option value="${r}">${r}</option>`).join('')}
+        </select>
+      </td>
+      <td class="p-3">
+        <input type="number" name="links[${index}][order]" value="${index + 1}" min="1" class="w-20 px-2 py-1 rounded bg-discord-dark-300 text-white" />
+      </td>
+      <td class="p-3 text-right">
+        <button type="button" class="deleteLink text-red-400">Delete</button>
+      </td>`;
+    tbody.appendChild(row);
+    updateOrders();
+  });
+
+  tbody.addEventListener('click', e => {
+    if (e.target.classList.contains('deleteLink')) {
+      e.target.closest('tr').remove();
+      updateOrders();
+    }
+  });
+
+  function updateOrders() {
+    [...tbody.querySelectorAll('tr')].forEach((row, idx) => {
+      row.querySelectorAll('input, select').forEach(input => {
+        const name = input.getAttribute('name');
+        if (name) {
+          const newName = name.replace(/links\[\d+\]/, `links[${idx}]`);
+          input.setAttribute('name', newName);
+        }
+      });
+      const orderInput = row.querySelector('input[name$="[order]"]');
+      if (orderInput) orderInput.value = idx + 1;
+    });
+  }
+
+  document.getElementById('linksForm').addEventListener('submit', async function(e) {
+    e.preventDefault();
+    const formData = new FormData(this);
+    const links = [];
+    for (const [key, value] of formData.entries()) {
+      const match = key.match(/^links\[(\d+)\]\[(label|url|order)\]$/);
+      if (!match) continue;
+      const idx = parseInt(match[1]);
+      if (!links[idx]) links[idx] = {};
+      links[idx][match[2]] = value;
+    }
+    const response = await fetch('/admin/landing/navbar', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ links })
+    });
+    if (response.ok) {
+      window.location.reload();
+    }
+  });
+</script>

--- a/src/modules/landing/views/layouts/landing.ejs
+++ b/src/modules/landing/views/layouts/landing.ejs
@@ -26,7 +26,8 @@
         }
     </script>
 </head>
-<body class="min-h-screen flex flex-col bg-background"></body>
+<body class="min-h-screen flex flex-col bg-background">
+    <%- include('../partials/navbar', { botName, navLinks, theme }) %>
     <%- content %>
 </body>
 </html>

--- a/src/modules/landing/views/partials/navbar.ejs
+++ b/src/modules/landing/views/partials/navbar.ejs
@@ -1,0 +1,22 @@
+<nav id="navbar" class="fixed top-0 left-0 w-full z-50 transition-colors">
+    <div class="max-w-7xl mx-auto px-4 py-4 flex justify-between items-center">
+        <a href="/" class="text-xl font-bold text-textMain"><%= botName %></a>
+        <div class="space-x-4">
+            <% navLinks.forEach(link => { %>
+                <a href="<%= link.url %>" class="text-textMain hover:text-accent"><%= link.label %></a>
+            <% }) %>
+        </div>
+    </div>
+</nav>
+<script>
+    const nav = document.getElementById('navbar');
+    function updateNav(){
+        if(window.scrollY <= 0){
+            nav.style.background = 'transparent';
+        }else{
+            nav.style.background = '<%= theme.background %>';
+        }
+    }
+    document.addEventListener('scroll', updateNav);
+    updateNav();
+</script>


### PR DESCRIPTION
## Summary
- create default navbar links
- render navbar from database in landing layout
- allow admin to manage navbar links with dropdown of existing routes
- expose new admin page in Landing sidebar

## Testing
- `npx eslint .` *(fails: Need to install eslint)*

------
https://chatgpt.com/codex/tasks/task_e_6888eb937d5c832fa60fcde98457fd4f