### PR TITLE
chore: upgrade admin module to 1.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@distube/yt-dlp": "^2.0.1",
         "@distube/ytdl-core": "^4.16.12",
         "@octokit/rest": "^22.0.0",
-        "@zumito-team/admin-module": "^1.5.0",
+        "@zumito-team/admin-module": "^1.6.0",
         "@zumito-team/user-panel-module": "^0.9.0",
         "canvas": "^2.11.2",
         "discord.js": "^14.21.0",
@@ -3149,9 +3149,10 @@
       }
     },
     "node_modules/@zumito-team/admin-module": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@zumito-team/admin-module/-/admin-module-1.5.0.tgz",
-      "integrity": "sha512-fD8/8JB+Ik3SftDKXjeMz3KI27IgoZAvfmq1Jkspxqjfw+bNoDAnr13B4myJwKyRsfQpK/u9wLDF4HiGOAG+Ew==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@zumito-team/admin-module/-/admin-module-1.6.0.tgz",
+      "integrity": "sha512-47XtnZu06O8rgA0yJ+jG8f9iLKUEn5s6zs4QYwXs+Dq7u4CJvSKHGh4bSJ9YQOb8YdcwdHTV92jWopHa9oxVPw==",
+      "license": "ISC",
       "dependencies": {
         "ejs": "^3.1.10",
         "jose": "^6.0.12",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@distube/yt-dlp": "^2.0.1",
     "@distube/ytdl-core": "^4.16.12",
     "@octokit/rest": "^22.0.0",
-    "@zumito-team/admin-module": "^1.5.0",
+    "@zumito-team/admin-module": "^1.6.0",
     "@zumito-team/user-panel-module": "^0.9.0",
     "canvas": "^2.11.2",
     "discord.js": "^14.21.0",


### PR DESCRIPTION
## Summary
- bump @zumito-team/admin-module to 1.6.0

## Testing
- `npx eslint .` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*

------
https://chatgpt.com/codex/tasks/task_e_68acd4f16a20832fbb07a3c25581945f