### PR TITLE
feat(tickets): add setup command for ticket panels

### DIFF
--- a/src/modules/tickets/commands/setup.ts
+++ b/src/modules/tickets/commands/setup.ts
@@ -1,0 +1,153 @@
+import { Command, CommandParameters, ButtonPressedParams, SelectMenuParameters, ModalSubmitParameters } from "zumito-framework";
+import { PermissionsBitField, MessageFlags } from "zumito-framework/discord";
+import { TicketPanelService } from "../services/TicketPanelService";
+import { SetupState } from "../services/setup/SetupState";
+import { SetupStartActionRowBuilder } from "../services/setup/SetupStartActionRowBuilder";
+import { SetupNameModalBuilder } from "../services/setup/SetupNameModalBuilder";
+import { SetupSelectMenuBuilder } from "../services/setup/SetupSelectMenuBuilder";
+import { SetupEmbedBuilder } from "../services/setup/SetupEmbedBuilder";
+
+export class Setup extends Command {
+    name = "setup";
+    description = "Configura paneles de tickets";
+    categories = ["tickets"];
+    userPermissions: bigint[] = [PermissionsBitField.Flags.Administrator];
+
+    private setups: Map<string, SetupState> = new Map();
+
+    async execute({ interaction, message }: CommandParameters): Promise<void> {
+        const guild = interaction?.guild || message?.guild;
+        if (!guild) return;
+        const panelService = new TicketPanelService();
+        const panels = await panelService.getTicketPanels(guild.id);
+
+        const row = new SetupStartActionRowBuilder().getRow();
+
+        const content = panels.length === 0
+            ? "Nunca has usado este bot en este servidor. Para continuar, dale al botón para crear un panel."
+            : "Gestiona tus paneles o crea uno nuevo.";
+
+        await (interaction || message)!.reply({
+            content,
+            components: [row],
+            flags: interaction ? MessageFlags.Ephemeral : undefined,
+        });
+    }
+
+    async buttonPressed({ interaction, path }: ButtonPressedParams): Promise<void> {
+        if (path[0] !== "setup") return;
+        if (path[1] !== "create") return;
+        if (!interaction.guild) return;
+
+        const panelService = new TicketPanelService();
+        const panels = await panelService.getTicketPanels(interaction.guild.id);
+        let defaultName = "New Panel";
+        let counter = 0;
+        while (panels.some(p => p.name === defaultName)) {
+            counter++;
+            defaultName = `New Panel ${counter}`;
+        }
+
+        const modal = new SetupNameModalBuilder().getModal(defaultName);
+
+        await interaction.showModal(modal);
+        this.setups.set(interaction.user.id, { guildId: interaction.guild.id });
+    }
+
+    async modalSubmit({ interaction, path }: ModalSubmitParameters): Promise<void> {
+        if (path[0] !== "setup" || path[1] !== "name") return;
+        const state = this.setups.get(interaction.user.id);
+        if (!state) return;
+
+        state.name = interaction.fields.getTextInputValue("name");
+
+        const selectBuilder = new SetupSelectMenuBuilder();
+        const row = selectBuilder.roles();
+        const embed = new SetupEmbedBuilder().getEmbed(state, "Selecciona los roles de soporte.");
+        await interaction.reply({
+            embeds: [embed],
+            components: [row],
+            flags: MessageFlags.Ephemeral,
+        });
+    }
+
+    async selectMenu({ interaction, path }: SelectMenuParameters): Promise<void> {
+        if (path[0] !== "setup") return;
+        const state = this.setups.get(interaction.user.id);
+        if (!state) return;
+
+        const selectBuilder = new SetupSelectMenuBuilder();
+        const embedBuilder = new SetupEmbedBuilder();
+
+        switch (path[1]) {
+        case "roles": {
+            state.supportRoles = interaction.values;
+            const row = selectBuilder.transcript();
+            const embed = embedBuilder.getEmbed(state, "Selecciona el canal de transcripción (opcional).");
+            await interaction.update({
+                embeds: [embed],
+                components: [row],
+            });
+            break;
+        }
+        case "transcript": {
+            state.transcriptChannelId = interaction.values[0] || null;
+            const row = selectBuilder.openCategory();
+            const embed = embedBuilder.getEmbed(state, "Selecciona la categoría para los tickets abiertos (opcional).");
+            await interaction.update({
+                embeds: [embed],
+                components: [row],
+            });
+            break;
+        }
+        case "open": {
+            state.openCategoryId = interaction.values[0] || null;
+            const row = selectBuilder.closedCategory();
+            const embed = embedBuilder.getEmbed(state, "Selecciona la categoría para los tickets cerrados (opcional).");
+            await interaction.update({
+                embeds: [embed],
+                components: [row],
+            });
+            break;
+        }
+        case "closed": {
+            state.closedCategoryId = interaction.values[0] || null;
+            const row = selectBuilder.sendChannel();
+            const embed = embedBuilder.getEmbed(state, "Selecciona el canal donde enviar el panel.");
+            await interaction.update({
+                embeds: [embed],
+                components: [row],
+            });
+            break;
+        }
+        case "send": {
+            state.sendChannelId = interaction.values[0];
+            const panelService = new TicketPanelService();
+            const panel = await panelService.createTicketPanel(state.guildId, {
+                name: state.name,
+                supportRoles: state.supportRoles || [],
+                transcriptChannelId: state.transcriptChannelId || null,
+                openCategoryId: state.openCategoryId || null,
+                closedCategoryId: state.closedCategoryId || null,
+                embed: {
+                    title: state.name,
+                    description: "Pulsa el botón para crear un ticket",
+                    color: "#5865F2"
+                },
+                button: {
+                    label: "Crear ticket",
+                }
+            });
+            await panelService.sendTicketPanel(panel._id.toString(), state.sendChannelId!);
+            this.setups.delete(interaction.user.id);
+            const embed = embedBuilder.getEmbed(state, "Panel creado y enviado correctamente.");
+            await interaction.update({
+                embeds: [embed],
+                components: [],
+            });
+            break;
+        }
+        }
+    }
+
+}

--- a/src/modules/tickets/services/setup/SetupEmbedBuilder.ts
+++ b/src/modules/tickets/services/setup/SetupEmbedBuilder.ts
@@ -1,0 +1,11 @@
+import { EmbedBuilder } from "zumito-framework/discord";
+import { SetupState } from "./SetupState";
+
+export class SetupEmbedBuilder {
+    getEmbed(state: SetupState, description: string) {
+        return new EmbedBuilder()
+            .setTitle("Configuración del panel")
+            .setDescription(`${description}\n\nNombre actual: **${state.name || "Sin nombre"}**`)
+            .setColor("#5865F2");
+    }
+}

--- a/src/modules/tickets/services/setup/SetupNameModalBuilder.ts
+++ b/src/modules/tickets/services/setup/SetupNameModalBuilder.ts
@@ -1,0 +1,20 @@
+import { ActionRowBuilder, ModalBuilder, TextInputBuilder, TextInputStyle } from "zumito-framework/discord";
+
+export class SetupNameModalBuilder {
+    getModal(defaultName: string) {
+        const modal = new ModalBuilder()
+            .setCustomId("setup.name")
+            .setTitle("Nombre del panel");
+
+        const nameInput = new TextInputBuilder()
+            .setCustomId("name")
+            .setLabel("Nombre del panel")
+            .setStyle(TextInputStyle.Short)
+            .setRequired(true)
+            .setValue(defaultName);
+
+        const row: any = new ActionRowBuilder<TextInputBuilder>().addComponents(nameInput);
+        modal.addComponents(row);
+        return modal;
+    }
+}

--- a/src/modules/tickets/services/setup/SetupSelectMenuBuilder.ts
+++ b/src/modules/tickets/services/setup/SetupSelectMenuBuilder.ts
@@ -1,0 +1,52 @@
+import { ActionRowBuilder, RoleSelectMenuBuilder, ChannelSelectMenuBuilder, ChannelType } from "zumito-framework/discord";
+
+export class SetupSelectMenuBuilder {
+    roles() {
+        const select = new RoleSelectMenuBuilder()
+            .setCustomId("setup.roles")
+            .setPlaceholder("Roles de soporte")
+            .setMinValues(0)
+            .setMaxValues(25);
+        return new ActionRowBuilder<RoleSelectMenuBuilder>().addComponents(select);
+    }
+
+    transcript() {
+        const select = new ChannelSelectMenuBuilder()
+            .setCustomId("setup.transcript")
+            .setPlaceholder("Canal de transcripción (opcional)")
+            .setChannelTypes(ChannelType.GuildText)
+            .setMinValues(0)
+            .setMaxValues(1);
+        return new ActionRowBuilder<ChannelSelectMenuBuilder>().addComponents(select);
+    }
+
+    openCategory() {
+        const select = new ChannelSelectMenuBuilder()
+            .setCustomId("setup.open")
+            .setPlaceholder("Categoría de tickets abiertos (opcional)")
+            .setChannelTypes(ChannelType.GuildCategory)
+            .setMinValues(0)
+            .setMaxValues(1);
+        return new ActionRowBuilder<ChannelSelectMenuBuilder>().addComponents(select);
+    }
+
+    closedCategory() {
+        const select = new ChannelSelectMenuBuilder()
+            .setCustomId("setup.closed")
+            .setPlaceholder("Categoría de tickets cerrados (opcional)")
+            .setChannelTypes(ChannelType.GuildCategory)
+            .setMinValues(0)
+            .setMaxValues(1);
+        return new ActionRowBuilder<ChannelSelectMenuBuilder>().addComponents(select);
+    }
+
+    sendChannel() {
+        const select = new ChannelSelectMenuBuilder()
+            .setCustomId("setup.send")
+            .setPlaceholder("Canal donde enviar el panel")
+            .setChannelTypes(ChannelType.GuildText)
+            .setMinValues(1)
+            .setMaxValues(1);
+        return new ActionRowBuilder<ChannelSelectMenuBuilder>().addComponents(select);
+    }
+}

--- a/src/modules/tickets/services/setup/SetupStartActionRowBuilder.ts
+++ b/src/modules/tickets/services/setup/SetupStartActionRowBuilder.ts
@@ -1,0 +1,12 @@
+import { ActionRowBuilder, ButtonBuilder, ButtonStyle } from "zumito-framework/discord";
+
+export class SetupStartActionRowBuilder {
+    getRow() {
+        return new ActionRowBuilder<ButtonBuilder>().addComponents(
+            new ButtonBuilder()
+                .setCustomId("setup.create")
+                .setLabel("Crear panel")
+                .setStyle(ButtonStyle.Primary)
+        );
+    }
+}

--- a/src/modules/tickets/services/setup/SetupState.ts
+++ b/src/modules/tickets/services/setup/SetupState.ts
@@ -1,0 +1,9 @@
+export interface SetupState {
+    guildId: string;
+    name?: string;
+    supportRoles?: string[];
+    transcriptChannelId?: string | null;
+    openCategoryId?: string | null;
+    closedCategoryId?: string | null;
+    sendChannelId?: string;
+}


### PR DESCRIPTION
## Summary
- extract reusable setup components into dedicated services
- show panel name in interactive setup embed

## Testing
- `npm install` *(failed: connect ENETUNREACH 140.82.114.4:443)*
- `npx eslint .` *(failed: Cannot find package '@typescript-eslint/eslint-plugin')*

------
https://chatgpt.com/codex/tasks/task_e_689a0d1b71c0832f87fbcd10422f6ec9