### PR TITLE
docs: organize component builders under services

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,8 @@ Estas directrices aplican a cualquier cambio en este repositorio.
 
 ## Servicios
 - Crea servicios siempre que sea posible para modularizar la lógica.
+- Genera embeds, botones u otros componentes dentro de los servicios de cada módulo.
+- Organiza estos servicios en la carpeta `services` del módulo, con subcarpetas específicas como `embedBuilder`, `buttonBuilder`, etc.
 
 ## Internacionalización
 - Evita texto codificado; utiliza siempre el sistema de traducciones.


### PR DESCRIPTION
## Summary
- clarify that embeds and buttons should be built as services
- recommend storing component builders in module `services` subfolders (e.g., `embedBuilder`, `buttonBuilder`)

## Testing
- `npx eslint .` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*


------
https://chatgpt.com/codex/tasks/task_e_68b5fca9d2ec832fa0080f5b2d865562