### PR TITLE
feat: add game server listing module

### DIFF
--- a/src/modules/gameServers/commands/addserver.ts
+++ b/src/modules/gameServers/commands/addserver.ts
@@ -1,0 +1,27 @@
+import { Command, CommandArgDefinition, CommandParameters, ServiceContainer } from "zumito-framework";
+import { GameServerService } from "../services/GameServerService.js";
+
+export class AddServerCommand extends Command {
+    name = "addserver";
+    description = "Adds a Minecraft server to the listing";
+    categories = ["minecraft"];
+    args: CommandArgDefinition[] = [
+        { name: "game", type: "string", optional: false },
+        { name: "ip", type: "string", optional: false },
+        { name: "name", type: "string", optional: true }
+    ];
+    botPermissions = ["VIEW_CHANNEL", "SEND_MESSAGES"];
+
+    async execute({ message, interaction, args, trans }: CommandParameters): Promise<void> {
+        const game = String(args.get("game")).toLowerCase();
+        const ip = args.get("ip");
+        const name = args.get("name") || ip;
+        if (game !== "minecraft") {
+            (message || interaction)?.reply({ content: trans("invalidGame"), allowedMentions: { repliedUser: false } });
+            return;
+        }
+        const service = ServiceContainer.getService(GameServerService) as GameServerService;
+        await service.addServer({ game, ip, name });
+        (message || interaction)?.reply({ content: trans("success"), allowedMentions: { repliedUser: false } });
+    }
+}

--- a/src/modules/gameServers/commands/listservers.ts
+++ b/src/modules/gameServers/commands/listservers.ts
@@ -1,0 +1,19 @@
+import { Command, CommandArgDefinition, CommandParameters, ServiceContainer } from "zumito-framework";
+import { ServerListEmbedService } from "../services/embedBuilder/ServerListEmbedService.js";
+
+export class ListServersCommand extends Command {
+    name = "gameservers";
+    description = "Shows the Minecraft server list";
+    categories = ["minecraft"];
+    args: CommandArgDefinition[] = [
+        { name: "game", type: "string", optional: true }
+    ];
+    botPermissions = ["VIEW_CHANNEL", "SEND_MESSAGES", "EMBED_LINKS"];
+
+    async execute({ message, interaction, args, trans }: CommandParameters): Promise<void> {
+        const game = String(args.get("game") || "minecraft").toLowerCase();
+        const embedService = ServiceContainer.getService(ServerListEmbedService) as ServerListEmbedService;
+        const embed = await embedService.build(game, trans);
+        (message || interaction)?.reply({ embeds: [embed], allowedMentions: { repliedUser: false } });
+    }
+}

--- a/src/modules/gameServers/index.ts
+++ b/src/modules/gameServers/index.ts
@@ -1,0 +1,13 @@
+import { Module, ServiceContainer } from "zumito-framework";
+import { GameServerService } from "./services/GameServerService.js";
+import { ServerListEmbedService } from "./services/embedBuilder/ServerListEmbedService.js";
+import { ServerListViewService } from "./services/ServerListViewService.js";
+
+export class GameServersModule extends Module {
+    constructor(modulePath: string) {
+        super(modulePath);
+        ServiceContainer.addService(GameServerService, [], true);
+        ServiceContainer.addService(ServerListEmbedService, [], true);
+        ServiceContainer.addService(ServerListViewService, [], true);
+    }
+}

--- a/src/modules/gameServers/routes/ServerLanding.ts
+++ b/src/modules/gameServers/routes/ServerLanding.ts
@@ -1,0 +1,36 @@
+import { Route, RouteMethod, ServiceContainer } from "zumito-framework";
+import { GameServerService } from "../services/GameServerService.js";
+import { ServerListViewService } from "../services/ServerListViewService.js";
+import ejs from "ejs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export class ServerLanding extends Route {
+    method = RouteMethod.get;
+    path = '/servers/:game';
+
+    constructor(
+        private serverService: GameServerService = ServiceContainer.getService(GameServerService),
+        private viewService: ServerListViewService = ServiceContainer.getService(ServerListViewService)
+    ) {
+        super();
+    }
+
+    async execute(req: any, res: any) {
+        const game = String(req.params.game).toLowerCase();
+        const servers = await this.serverService.getServers(game);
+        const list = [];
+        for (const server of servers) {
+            const status = await this.serverService.getStatus(server);
+            list.push({ ...server, status });
+        }
+        const content = await ejs.renderFile(
+            path.join(__dirname, '../views/server-list.ejs'),
+            { servers: list, game }
+        );
+        const html = await this.viewService.render({ title: `${game} servers`, content });
+        res.send(html);
+    }
+}

--- a/src/modules/gameServers/services/GameServerService.ts
+++ b/src/modules/gameServers/services/GameServerService.ts
@@ -1,0 +1,38 @@
+import { ServiceContainer, ZumitoFramework } from "zumito-framework";
+
+export interface GameServer {
+    game: string;
+    name: string;
+    ip: string;
+}
+
+export class GameServerService {
+    private framework: ZumitoFramework;
+    private db: any;
+
+    constructor() {
+        this.framework = ServiceContainer.getService(ZumitoFramework);
+        this.db = this.framework.database;
+    }
+
+    async addServer(server: GameServer): Promise<void> {
+        await this.db.collection("gameServers").insertOne(server);
+    }
+
+    async getServers(game: string): Promise<GameServer[]> {
+        return await this.db.collection("gameServers").find({ game }).toArray();
+    }
+
+    async getStatus(server: GameServer): Promise<{ online: boolean; players?: { online: number; max: number }; version?: string }>
+ {
+        if (server.game === "minecraft") {
+            const res = await fetch(`https://api.mcsrvstat.us/2/${encodeURIComponent(server.ip)}`);
+            const data = await res.json().catch(() => null);
+            if (data && data.online) {
+                return { online: true, players: data.players, version: data.version };
+            }
+            return { online: false };
+        }
+        return { online: false };
+    }
+}

--- a/src/modules/gameServers/services/ServerListViewService.ts
+++ b/src/modules/gameServers/services/ServerListViewService.ts
@@ -1,0 +1,11 @@
+import ejs from "ejs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+export class ServerListViewService {
+    private static layoutPath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../views/layouts/server-list.ejs');
+
+    async render({ title, content }: { title: string; content: string; }): Promise<string> {
+        return await ejs.renderFile(ServerListViewService.layoutPath, { title, content });
+    }
+}

--- a/src/modules/gameServers/services/embedBuilder/ServerListEmbedService.ts
+++ b/src/modules/gameServers/services/embedBuilder/ServerListEmbedService.ts
@@ -1,0 +1,29 @@
+import { EmbedBuilder } from "zumito-framework/discord";
+import { ServiceContainer } from "zumito-framework";
+import { GameServerService } from "../GameServerService.js";
+import { config } from "../../../../config/index.js";
+
+export class ServerListEmbedService {
+    constructor(private gameServerService: GameServerService = ServiceContainer.getService(GameServerService)) {}
+
+    async build(game: string, trans: (key: string, params?: Record<string, any>) => string): Promise<EmbedBuilder> {
+        const servers = await this.gameServerService.getServers(game);
+        const embed = new EmbedBuilder()
+            .setTitle(trans('title', { game }))
+            .setColor(config.colors.default);
+
+        if (servers.length === 0) {
+            embed.setDescription(trans('empty'));
+            return embed;
+        }
+
+        for (const server of servers) {
+            const status = await this.gameServerService.getStatus(server);
+            const value = status.online
+                ? trans('online', { players: status.players?.online, max: status.players?.max, version: status.version })
+                : trans('offline');
+            embed.addFields({ name: server.name, value });
+        }
+        return embed;
+    }
+}

--- a/src/modules/gameServers/translations/command/addserver/en.json
+++ b/src/modules/gameServers/translations/command/addserver/en.json
@@ -1,0 +1,15 @@
+{
+    "description": "Adds a Minecraft server to the global list.",
+    "success": "Server added successfully.",
+    "invalidGame": "Only the game 'minecraft' is currently supported.",
+    "arguments": {
+        "game": { "name": "game" },
+        "ip": { "name": "ip" },
+        "name": { "name": "name" }
+    },
+    "args": {
+        "game": { "description": "Game name" },
+        "ip": { "description": "Server address" },
+        "name": { "description": "Server name" }
+    }
+}

--- a/src/modules/gameServers/translations/command/addserver/es.json
+++ b/src/modules/gameServers/translations/command/addserver/es.json
@@ -1,0 +1,15 @@
+{
+    "description": "Agrega un servidor de Minecraft a la lista global.",
+    "success": "Servidor agregado correctamente.",
+    "invalidGame": "Actualmente solo se admite el juego 'minecraft'.",
+    "arguments": {
+        "game": { "name": "juego" },
+        "ip": { "name": "ip" },
+        "name": { "name": "nombre" }
+    },
+    "args": {
+        "game": { "description": "Nombre del juego" },
+        "ip": { "description": "Dirección del servidor" },
+        "name": { "description": "Nombre del servidor" }
+    }
+}

--- a/src/modules/gameServers/translations/command/listservers/en.json
+++ b/src/modules/gameServers/translations/command/listservers/en.json
@@ -1,0 +1,13 @@
+{
+    "description": "Shows Minecraft servers added by users.",
+    "title": "{game} servers",
+    "online": "Online {players}/{max} - {version}",
+    "offline": "Offline",
+    "empty": "No servers have been added yet.",
+    "arguments": {
+        "game": { "name": "game" }
+    },
+    "args": {
+        "game": { "description": "Game name" }
+    }
+}

--- a/src/modules/gameServers/translations/command/listservers/es.json
+++ b/src/modules/gameServers/translations/command/listservers/es.json
@@ -1,0 +1,13 @@
+{
+    "description": "Muestra servidores de Minecraft agregados por usuarios.",
+    "title": "Servidores de {game}",
+    "online": "En línea {players}/{max} - {version}",
+    "offline": "Fuera de línea",
+    "empty": "Aún no se han agregado servidores.",
+    "arguments": {
+        "game": { "name": "juego" }
+    },
+    "args": {
+        "game": { "description": "Nombre del juego" }
+    }
+}

--- a/src/modules/gameServers/views/layouts/server-list.ejs
+++ b/src/modules/gameServers/views/layouts/server-list.ejs
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title><%= title %></title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="min-h-screen bg-gray-900 text-white">
+    <%- content %>
+</body>
+</html>

--- a/src/modules/gameServers/views/server-list.ejs
+++ b/src/modules/gameServers/views/server-list.ejs
@@ -1,0 +1,15 @@
+<main class="p-8">
+    <h1 class="text-3xl font-bold mb-4"><%= game %> Servers</h1>
+    <div class="grid gap-4">
+        <% servers.forEach(s => { %>
+            <div class="p-4 rounded bg-gray-800">
+                <h2 class="text-xl font-semibold mb-2"><%= s.name %></h2>
+                <% if (s.status.online) { %>
+                    <p class="text-green-400">Online - <%= s.status.players.online %>/<%= s.status.players.max %> - <%= s.status.version %></p>
+                <% } else { %>
+                    <p class="text-red-400">Offline</p>
+                <% } %>
+            </div>
+        <% }) %>
+    </div>
+</main>


### PR DESCRIPTION
## Summary
- add game server listing module with commands to add and view servers
- support server status fetching and embed generation for listings
- include web route to display servers with status

## Testing
- `npx eslint .` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*

------
https://chatgpt.com/codex/tasks/task_e_68b61a41da8c832faa7489a3e7a4f455