### PR TITLE
feat: add game server listing module

### DIFF
--- a/src/modules/gameServers/commands/addserver.ts
+++ b/src/modules/gameServers/commands/addserver.ts
@@ -1,0 +1,28 @@
+import { Command, CommandArgDefinition, CommandParameters, ServiceContainer } from "zumito-framework";
+import { GameServerService } from "../services/GameServerService.js";
+
+export class AddServerCommand extends Command {
+    name = "addserver";
+    description = "Adds a Minecraft server to the listing";
+    categories = ["minecraft"];
+    args: CommandArgDefinition[] = [
+        { name: "game", type: "string", optional: false },
+        { name: "ip", type: "string", optional: false },
+        { name: "name", type: "string", optional: true }
+    ];
+    botPermissions = ["VIEW_CHANNEL", "SEND_MESSAGES"];
+
+    async execute({ message, interaction, args, trans }: CommandParameters): Promise<void> {
+        const game = String(args.get("game")).toLowerCase();
+        const ip = args.get("ip");
+        const name = args.get("name") || ip;
+        const ownerId = message?.author.id || interaction?.user.id || "";
+        if (game !== "minecraft") {
+            (message || interaction)?.reply({ content: trans("invalidGame"), allowedMentions: { repliedUser: false } });
+            return;
+        }
+        const service = ServiceContainer.getService(GameServerService) as GameServerService;
+        await service.addServer({ game, ip, name, ownerId });
+        (message || interaction)?.reply({ content: trans("success"), allowedMentions: { repliedUser: false } });
+    }
+}

--- a/src/modules/gameServers/commands/delserver.ts
+++ b/src/modules/gameServers/commands/delserver.ts
@@ -1,0 +1,23 @@
+import { Command, CommandArgDefinition, CommandParameters, ServiceContainer } from "zumito-framework";
+import { GameServerService } from "../services/GameServerService.js";
+
+export class DelServerCommand extends Command {
+    name = "delserver";
+    description = "Deletes a game server you added";
+    categories = ["minecraft"];
+    args: CommandArgDefinition[] = [
+        { name: "game", type: "string", optional: false },
+        { name: "ip", type: "string", optional: false }
+    ];
+    botPermissions = ["VIEW_CHANNEL", "SEND_MESSAGES"];
+
+    async execute({ message, interaction, args, trans }: CommandParameters): Promise<void> {
+        const game = String(args.get("game")).toLowerCase();
+        const ip = String(args.get("ip"));
+        const ownerId = message?.author.id || interaction?.user.id || "";
+        const service = ServiceContainer.getService(GameServerService) as GameServerService;
+        const deleted = await service.removeServer(game, ip, ownerId);
+        const content = deleted ? trans("success") : trans("notFound");
+        (message || interaction)?.reply({ content, allowedMentions: { repliedUser: false } });
+    }
+}

--- a/src/modules/gameServers/commands/editserver.ts
+++ b/src/modules/gameServers/commands/editserver.ts
@@ -1,0 +1,27 @@
+import { Command, CommandArgDefinition, CommandParameters, ServiceContainer } from "zumito-framework";
+import { GameServerService } from "../services/GameServerService.js";
+
+export class EditServerCommand extends Command {
+    name = "editserver";
+    description = "Edits a game server you added";
+    categories = ["minecraft"];
+    args: CommandArgDefinition[] = [
+        { name: "game", type: "string", optional: false },
+        { name: "ip", type: "string", optional: false },
+        { name: "newip", type: "string", optional: true },
+        { name: "name", type: "string", optional: true }
+    ];
+    botPermissions = ["VIEW_CHANNEL", "SEND_MESSAGES"];
+
+    async execute({ message, interaction, args, trans }: CommandParameters): Promise<void> {
+        const game = String(args.get("game")).toLowerCase();
+        const ip = String(args.get("ip"));
+        const newIp = args.get("newip") as string | undefined;
+        const name = args.get("name") as string | undefined;
+        const ownerId = message?.author.id || interaction?.user.id || "";
+        const service = ServiceContainer.getService(GameServerService) as GameServerService;
+        const updated = await service.updateServer(game, ip, ownerId, { ip: newIp, name });
+        const content = updated ? trans("success") : trans("notFound");
+        (message || interaction)?.reply({ content, allowedMentions: { repliedUser: false } });
+    }
+}

--- a/src/modules/gameServers/commands/listservers.ts
+++ b/src/modules/gameServers/commands/listservers.ts
@@ -1,0 +1,19 @@
+import { Command, CommandArgDefinition, CommandParameters, ServiceContainer } from "zumito-framework";
+import { ServerListEmbedService } from "../services/embedBuilder/ServerListEmbedService.js";
+
+export class ListServersCommand extends Command {
+    name = "gameservers";
+    description = "Shows the Minecraft server list";
+    categories = ["minecraft"];
+    args: CommandArgDefinition[] = [
+        { name: "game", type: "string", optional: true }
+    ];
+    botPermissions = ["VIEW_CHANNEL", "SEND_MESSAGES", "EMBED_LINKS"];
+
+    async execute({ message, interaction, args, trans }: CommandParameters): Promise<void> {
+        const game = String(args.get("game") || "minecraft").toLowerCase();
+        const embedService = ServiceContainer.getService(ServerListEmbedService) as ServerListEmbedService;
+        const embed = await embedService.build(game, trans);
+        (message || interaction)?.reply({ embeds: [embed], allowedMentions: { repliedUser: false } });
+    }
+}

--- a/src/modules/gameServers/index.ts
+++ b/src/modules/gameServers/index.ts
@@ -1,0 +1,13 @@
+import { Module, ServiceContainer } from "zumito-framework";
+import { GameServerService } from "./services/GameServerService.js";
+import { ServerListEmbedService } from "./services/embedBuilder/ServerListEmbedService.js";
+import { ServerListViewService } from "./services/ServerListViewService.js";
+
+export class GameServersModule extends Module {
+    constructor(modulePath: string) {
+        super(modulePath);
+        ServiceContainer.addService(GameServerService, [], true);
+        ServiceContainer.addService(ServerListEmbedService, [], true);
+        ServiceContainer.addService(ServerListViewService, [], true);
+    }
+}

--- a/src/modules/gameServers/routes/GameLanding.ts
+++ b/src/modules/gameServers/routes/GameLanding.ts
@@ -1,0 +1,30 @@
+import { Route, RouteMethod, ServiceContainer } from "zumito-framework";
+import { GameServerService } from "../services/GameServerService.js";
+import { ServerListViewService } from "../services/ServerListViewService.js";
+import ejs from "ejs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export class GameLanding extends Route {
+    method = RouteMethod.get;
+    path = '/game-servers';
+
+    constructor(
+        private serverService: GameServerService = ServiceContainer.getService(GameServerService),
+        private viewService: ServerListViewService = ServiceContainer.getService(ServerListViewService)
+    ) {
+        super();
+    }
+
+    async execute(req: any, res: any) {
+        const games = await this.serverService.getGames();
+        const content = await ejs.renderFile(
+            path.join(__dirname, '../views/game-landing.ejs'),
+            { games }
+        );
+        const html = await this.viewService.render({ title: 'Game servers', content });
+        res.send(html);
+    }
+}

--- a/src/modules/gameServers/routes/ServerLanding.ts
+++ b/src/modules/gameServers/routes/ServerLanding.ts
@@ -1,0 +1,36 @@
+import { Route, RouteMethod, ServiceContainer } from "zumito-framework";
+import { GameServerService } from "../services/GameServerService.js";
+import { ServerListViewService } from "../services/ServerListViewService.js";
+import ejs from "ejs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export class ServerLanding extends Route {
+    method = RouteMethod.get;
+    path = '/game-servers/:game';
+
+    constructor(
+        private serverService: GameServerService = ServiceContainer.getService(GameServerService),
+        private viewService: ServerListViewService = ServiceContainer.getService(ServerListViewService)
+    ) {
+        super();
+    }
+
+    async execute(req: any, res: any) {
+        const game = String(req.params.game).toLowerCase();
+        const servers = await this.serverService.getServers(game);
+        const list = [];
+        for (const server of servers) {
+            const status = await this.serverService.getStatus(server);
+            list.push({ ...server, status });
+        }
+        const content = await ejs.renderFile(
+            path.join(__dirname, '../views/server-list.ejs'),
+            { servers: list, game }
+        );
+        const html = await this.viewService.render({ title: `${game} servers`, content });
+        res.send(html);
+    }
+}

--- a/src/modules/gameServers/services/GameServerService.ts
+++ b/src/modules/gameServers/services/GameServerService.ts
@@ -1,0 +1,53 @@
+import { ServiceContainer, ZumitoFramework } from "zumito-framework";
+
+export interface GameServer {
+    game: string;
+    name: string;
+    ip: string;
+    ownerId: string;
+}
+
+export class GameServerService {
+    private framework: ZumitoFramework;
+    private db: any;
+
+    constructor() {
+        this.framework = ServiceContainer.getService(ZumitoFramework);
+        this.db = this.framework.database;
+    }
+
+    async addServer(server: GameServer): Promise<void> {
+        await this.db.collection("gameServers").insertOne(server);
+    }
+
+    async getServers(game: string): Promise<GameServer[]> {
+        return await this.db.collection("gameServers").find({ game }).toArray();
+    }
+
+    async getGames(): Promise<string[]> {
+        return await this.db.collection("gameServers").distinct("game");
+    }
+
+    async updateServer(game: string, ip: string, ownerId: string, update: { ip?: string; name?: string; }): Promise<boolean> {
+        const res = await this.db.collection("gameServers").updateOne({ game, ip, ownerId }, { $set: update });
+        return res.matchedCount > 0;
+    }
+
+    async removeServer(game: string, ip: string, ownerId: string): Promise<boolean> {
+        const res = await this.db.collection("gameServers").deleteOne({ game, ip, ownerId });
+        return res.deletedCount > 0;
+    }
+
+    async getStatus(server: GameServer): Promise<{ online: boolean; players?: { online: number; max: number }; version?: string }>
+ {
+        if (server.game === "minecraft") {
+            const res = await fetch(`https://api.mcsrvstat.us/2/${encodeURIComponent(server.ip)}`);
+            const data = await res.json().catch(() => null);
+            if (data && data.online) {
+                return { online: true, players: data.players, version: data.version };
+            }
+            return { online: false };
+        }
+        return { online: false };
+    }
+}

--- a/src/modules/gameServers/services/ServerListViewService.ts
+++ b/src/modules/gameServers/services/ServerListViewService.ts
@@ -1,0 +1,11 @@
+import ejs from "ejs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+export class ServerListViewService {
+    private static layoutPath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../views/layouts/server-list.ejs');
+
+    async render({ title, content }: { title: string; content: string; }): Promise<string> {
+        return await ejs.renderFile(ServerListViewService.layoutPath, { title, content });
+    }
+}

--- a/src/modules/gameServers/services/embedBuilder/ServerListEmbedService.ts
+++ b/src/modules/gameServers/services/embedBuilder/ServerListEmbedService.ts
@@ -1,0 +1,29 @@
+import { EmbedBuilder } from "zumito-framework/discord";
+import { ServiceContainer } from "zumito-framework";
+import { GameServerService } from "../GameServerService.js";
+import { config } from "../../../../config/index.js";
+
+export class ServerListEmbedService {
+    constructor(private gameServerService: GameServerService = ServiceContainer.getService(GameServerService)) {}
+
+    async build(game: string, trans: (key: string, params?: Record<string, any>) => string): Promise<EmbedBuilder> {
+        const servers = await this.gameServerService.getServers(game);
+        const embed = new EmbedBuilder()
+            .setTitle(trans('title', { game }))
+            .setColor(config.colors.default);
+
+        if (servers.length === 0) {
+            embed.setDescription(trans('empty'));
+            return embed;
+        }
+
+        for (const server of servers) {
+            const status = await this.gameServerService.getStatus(server);
+            const value = status.online
+                ? trans('online', { players: status.players?.online, max: status.players?.max, version: status.version })
+                : trans('offline');
+            embed.addFields({ name: server.name, value });
+        }
+        return embed;
+    }
+}

--- a/src/modules/gameServers/translations/command/addserver/en.json
+++ b/src/modules/gameServers/translations/command/addserver/en.json
@@ -1,0 +1,15 @@
+{
+    "description": "Adds a Minecraft server to the global list.",
+    "success": "Server added successfully.",
+    "invalidGame": "Only the game 'minecraft' is currently supported.",
+    "arguments": {
+        "game": { "name": "game" },
+        "ip": { "name": "ip" },
+        "name": { "name": "name" }
+    },
+    "args": {
+        "game": { "description": "Game name" },
+        "ip": { "description": "Server address" },
+        "name": { "description": "Server name" }
+    }
+}

--- a/src/modules/gameServers/translations/command/addserver/es.json
+++ b/src/modules/gameServers/translations/command/addserver/es.json
@@ -1,0 +1,15 @@
+{
+    "description": "Agrega un servidor de Minecraft a la lista global.",
+    "success": "Servidor agregado correctamente.",
+    "invalidGame": "Actualmente solo se admite el juego 'minecraft'.",
+    "arguments": {
+        "game": { "name": "juego" },
+        "ip": { "name": "ip" },
+        "name": { "name": "nombre" }
+    },
+    "args": {
+        "game": { "description": "Nombre del juego" },
+        "ip": { "description": "Dirección del servidor" },
+        "name": { "description": "Nombre del servidor" }
+    }
+}

--- a/src/modules/gameServers/translations/command/delserver/en.json
+++ b/src/modules/gameServers/translations/command/delserver/en.json
@@ -1,0 +1,13 @@
+{
+    "description": "Deletes a game server you added.",
+    "success": "Server removed successfully.",
+    "notFound": "Server not found or you are not the owner.",
+    "arguments": {
+        "game": { "name": "game" },
+        "ip": { "name": "ip" }
+    },
+    "args": {
+        "game": { "description": "Game name" },
+        "ip": { "description": "Server address" }
+    }
+}

--- a/src/modules/gameServers/translations/command/delserver/es.json
+++ b/src/modules/gameServers/translations/command/delserver/es.json
@@ -1,0 +1,13 @@
+{
+    "description": "Elimina un servidor que agregaste.",
+    "success": "Servidor eliminado correctamente.",
+    "notFound": "Servidor no encontrado o no eres el dueño.",
+    "arguments": {
+        "game": { "name": "game" },
+        "ip": { "name": "ip" }
+    },
+    "args": {
+        "game": { "description": "Nombre del juego" },
+        "ip": { "description": "Dirección del servidor" }
+    }
+}

--- a/src/modules/gameServers/translations/command/editserver/en.json
+++ b/src/modules/gameServers/translations/command/editserver/en.json
@@ -1,0 +1,17 @@
+{
+    "description": "Edits a game server you added.",
+    "success": "Server updated successfully.",
+    "notFound": "Server not found or you are not the owner.",
+    "arguments": {
+        "game": { "name": "game" },
+        "ip": { "name": "ip" },
+        "newip": { "name": "newip" },
+        "name": { "name": "name" }
+    },
+    "args": {
+        "game": { "description": "Game name" },
+        "ip": { "description": "Current server address" },
+        "newip": { "description": "New server address" },
+        "name": { "description": "New server name" }
+    }
+}

--- a/src/modules/gameServers/translations/command/editserver/es.json
+++ b/src/modules/gameServers/translations/command/editserver/es.json
@@ -1,0 +1,17 @@
+{
+    "description": "Edita un servidor que agregaste.",
+    "success": "Servidor actualizado correctamente.",
+    "notFound": "Servidor no encontrado o no eres el dueño.",
+    "arguments": {
+        "game": { "name": "game" },
+        "ip": { "name": "ip" },
+        "newip": { "name": "newip" },
+        "name": { "name": "name" }
+    },
+    "args": {
+        "game": { "description": "Nombre del juego" },
+        "ip": { "description": "Dirección actual del servidor" },
+        "newip": { "description": "Nueva dirección del servidor" },
+        "name": { "description": "Nuevo nombre del servidor" }
+    }
+}

--- a/src/modules/gameServers/translations/command/listservers/en.json
+++ b/src/modules/gameServers/translations/command/listservers/en.json
@@ -1,0 +1,13 @@
+{
+    "description": "Shows game servers added by users.",
+    "title": "{game} servers",
+    "online": "Online {players}/{max} - {version}",
+    "offline": "Offline",
+    "empty": "No servers have been added yet.",
+    "arguments": {
+        "game": { "name": "game" }
+    },
+    "args": {
+        "game": { "description": "Game name" }
+    }
+}

--- a/src/modules/gameServers/translations/command/listservers/es.json
+++ b/src/modules/gameServers/translations/command/listservers/es.json
@@ -1,0 +1,13 @@
+{
+    "description": "Muestra servidores de juegos agregados por usuarios.",
+    "title": "Servidores de {game}",
+    "online": "En línea {players}/{max} - {version}",
+    "offline": "Fuera de línea",
+    "empty": "Aún no se han agregado servidores.",
+    "arguments": {
+        "game": { "name": "juego" }
+    },
+    "args": {
+        "game": { "description": "Nombre del juego" }
+    }
+}

--- a/src/modules/gameServers/views/game-landing.ejs
+++ b/src/modules/gameServers/views/game-landing.ejs
@@ -1,0 +1,9 @@
+<main class="p-8">
+    <h1 class="text-3xl font-bold mb-4">Game Servers</h1>
+    <p class="mb-4">Select a game to discover community servers.</p>
+    <ul class="list-disc list-inside">
+        <% games.forEach(g => { %>
+            <li><a class="text-blue-400 underline" href="/game-servers/<%= g %>"><%= g %></a></li>
+        <% }) %>
+    </ul>
+</main>

--- a/src/modules/gameServers/views/layouts/server-list.ejs
+++ b/src/modules/gameServers/views/layouts/server-list.ejs
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title><%= title %></title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="min-h-screen bg-gray-900 text-white">
+    <%- content %>
+</body>
+</html>

--- a/src/modules/gameServers/views/server-list.ejs
+++ b/src/modules/gameServers/views/server-list.ejs
@@ -1,0 +1,15 @@
+<main class="p-8">
+    <h1 class="text-3xl font-bold mb-4"><%= game %> Servers</h1>
+    <div class="grid gap-4">
+        <% servers.forEach(s => { %>
+            <div class="p-4 rounded bg-gray-800">
+                <h2 class="text-xl font-semibold mb-2"><%= s.name %></h2>
+                <% if (s.status.online) { %>
+                    <p class="text-green-400">Online - <%= s.status.players.online %>/<%= s.status.players.max %> - <%= s.status.version %></p>
+                <% } else { %>
+                    <p class="text-red-400">Offline</p>
+                <% } %>
+            </div>
+        <% }) %>
+    </div>
+</main>


### PR DESCRIPTION
## Summary
- list servers under `/game-servers/:game` and add game landing at `/game-servers`
- track server owners and available games in game server service
- let creators edit or remove their servers through new commands

## Testing
- `npm install --no-audit --no-fund` *(fails: Package 'pixman-1' not found)*
- `npx eslint .` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*


------
https://chatgpt.com/codex/tasks/task_e_68b61a41da8c832faa7489a3e7a4f455