### PR TITLE
feat: add inventory module with view command

### DIFF
--- a/src/modules/inventory/commands/inventory.ts
+++ b/src/modules/inventory/commands/inventory.ts
@@ -1,0 +1,54 @@
+import { Command, CommandParameters, CommandType, ServiceContainer } from "zumito-framework";
+import { InventoryService, InventoryItem } from "../services/InventoryService";
+
+export class InventoryCommand extends Command {
+    name = "inventory";
+    description = "View your inventory.";
+    categories = ["inventory"];
+    examples = ["@user"];
+    usage = "inventory [user]";
+    type = CommandType.any;
+    args = [
+        { name: "user", type: "user", optional: true }
+    ];
+
+    async execute({ message, interaction, args, framework, guildSettings }: CommandParameters): Promise<void> {
+        const user = args.get("user") || message?.author || interaction?.user;
+        if (!user) return;
+        const guildId = message?.guild?.id || interaction?.guild?.id;
+        const inventoryService = ServiceContainer.getService(InventoryService) as InventoryService;
+
+        const globalItems = await inventoryService.getGlobalInventory(user.id);
+        const guildItems = guildId ? await inventoryService.getGuildInventory(user.id, guildId) : [];
+
+        const lines: string[] = [];
+        lines.push(framework.translations.get("command.inventory.title", guildSettings.lang, { user: `<@${user.id}>` }));
+        lines.push(framework.translations.get("command.inventory.globalTitle", guildSettings.lang));
+        if (globalItems.length === 0) {
+            lines.push(framework.translations.get("command.inventory.empty", guildSettings.lang));
+        } else {
+            lines.push(this.formatItems(globalItems, framework, guildSettings.lang));
+        }
+        if (guildId) {
+            lines.push(framework.translations.get("command.inventory.guildTitle", guildSettings.lang));
+            if (guildItems.length === 0) {
+                lines.push(framework.translations.get("command.inventory.empty", guildSettings.lang));
+            } else {
+                lines.push(this.formatItems(guildItems, framework, guildSettings.lang));
+            }
+        }
+        const content = lines.join("\n");
+        if (message) {
+            await message.reply(content);
+        } else if (interaction) {
+            await interaction.reply(content);
+        }
+    }
+
+    private formatItems(items: InventoryItem[], framework: any, lang: string): string {
+        return items
+            .map(i => `• [${framework.translations.get(i.name, lang)}](${i.iconUrl})${i.tags?.length ? ` (${i.tags.join(', ')})` : ''}`)
+            .join("\n");
+    }
+}
+

--- a/src/modules/inventory/index.ts
+++ b/src/modules/inventory/index.ts
@@ -1,0 +1,10 @@
+import { Module, ServiceContainer } from "zumito-framework";
+import { InventoryService } from "./services/InventoryService";
+
+export class InventoryModule extends Module {
+    constructor(modulePath: string) {
+        super(modulePath);
+        ServiceContainer.addService(InventoryService, [], true);
+    }
+}
+

--- a/src/modules/inventory/services/InventoryService.ts
+++ b/src/modules/inventory/services/InventoryService.ts
@@ -1,0 +1,35 @@
+import { ServiceContainer, ZumitoFramework } from "zumito-framework";
+
+export interface InventoryItem {
+    iconUrl: string;
+    name: string;
+    data: any[];
+    tags: string[];
+}
+
+export class InventoryService {
+    private framework: ZumitoFramework;
+
+    constructor() {
+        this.framework = ServiceContainer.getService(ZumitoFramework);
+    }
+
+    async addItem(userId: string, item: InventoryItem, guildId?: string): Promise<void> {
+        await this.framework.database.collection("inventories").updateOne(
+            { userId, guildId: guildId || null },
+            { $push: { items: item } },
+            { upsert: true }
+        );
+    }
+
+    async getGlobalInventory(userId: string): Promise<InventoryItem[]> {
+        const doc = await this.framework.database.collection("inventories").findOne({ userId, guildId: null });
+        return doc?.items || [];
+    }
+
+    async getGuildInventory(userId: string, guildId: string): Promise<InventoryItem[]> {
+        const doc = await this.framework.database.collection("inventories").findOne({ userId, guildId });
+        return doc?.items || [];
+    }
+}
+

--- a/src/modules/inventory/translations/command/inventory/en.json
+++ b/src/modules/inventory/translations/command/inventory/en.json
@@ -1,0 +1,7 @@
+{
+    "description": "View your inventory.",
+    "title": "Inventory for {user}",
+    "globalTitle": "Global",
+    "guildTitle": "Server",
+    "empty": "No items."
+}

--- a/src/modules/inventory/translations/command/inventory/es.json
+++ b/src/modules/inventory/translations/command/inventory/es.json
@@ -1,0 +1,7 @@
+{
+    "description": "Visualiza tu inventario.",
+    "title": "Inventario de {user}",
+    "globalTitle": "Global",
+    "guildTitle": "Servidor",
+    "empty": "Sin objetos."
+}


### PR DESCRIPTION
## Summary
- add inventory service storing items with metadata
- support global and guild inventories with `/inventory` command
- add English and Spanish translations for inventory texts

## Testing
- `npx eslint .` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*
- `npm install` *(fails: connect ENETUNREACH 140.82.112.3:443)*

------
https://chatgpt.com/codex/tasks/task_e_68b621b37ee0832fa1aa8aa888b03b6a