### PR TITLE
feat: add community translation service with voting and patch generation

### DIFF
--- a/src/modules/communityTranslations/routes/AdminTranslationsPatch.ts
+++ b/src/modules/communityTranslations/routes/AdminTranslationsPatch.ts
@@ -1,0 +1,35 @@
+import { Route, RouteMethod, ServiceContainer, TranslationManager } from "zumito-framework";
+import { AdminAuthService } from "@zumito-team/admin-module/services/AdminAuthService";
+import { CommunityTranslationService } from "../services/CommunityTranslationService";
+
+export class AdminTranslationsPatch extends Route {
+    method = RouteMethod.get;
+    path = '/admin/translations/patch';
+
+    constructor(
+        private auth: AdminAuthService = ServiceContainer.getService(AdminAuthService),
+        private communityService: CommunityTranslationService = ServiceContainer.getService(CommunityTranslationService),
+        private translator: TranslationManager = ServiceContainer.getService(TranslationManager),
+    ) {
+        super();
+    }
+
+    async execute(req: any, res: any) {
+        if (!await this.auth.isLoginValid(req).then(r => r.isValid)) {
+            return res.redirect('/admin/login');
+        }
+        const lang = req.query.lang || 'en';
+        req.lang = lang;
+        try {
+            const patch = await this.communityService.generatePatch();
+            if (!patch) {
+                return res.status(404).send(this.translator.get('community.noTranslations', lang));
+            }
+            res.set('Content-Type', 'text/plain');
+            res.send(patch);
+        } catch {
+            res.status(500).send(this.translator.get('community.error', lang));
+        }
+    }
+}
+

--- a/src/modules/communityTranslations/routes/UserPanelGetCommunityTranslations.ts
+++ b/src/modules/communityTranslations/routes/UserPanelGetCommunityTranslations.ts
@@ -1,0 +1,27 @@
+import { Route, RouteMethod, ServiceContainer } from "zumito-framework";
+import { UserPanelAuthService } from "@zumito-team/user-panel-module/services/UserPanelAuthService";
+import { CommunityTranslationService } from "../services/CommunityTranslationService";
+
+export class UserPanelGetCommunityTranslations extends Route {
+    method = RouteMethod.get;
+    path = '/panel/:lang/community-translations';
+
+    constructor(
+        private auth: UserPanelAuthService = ServiceContainer.getService(UserPanelAuthService),
+        private communityService: CommunityTranslationService = ServiceContainer.getService(CommunityTranslationService),
+    ) {
+        super();
+    }
+
+    async execute(req: any, res: any) {
+        const authData = await this.auth.isLoginValid(req);
+        if (!authData.isValid) {
+            return res.redirect('/panel/login');
+        }
+        const lang = req.params.lang;
+        req.lang = lang;
+        const proposals = await this.communityService.getCommunityTranslations(lang);
+        res.json(proposals);
+    }
+}
+

--- a/src/modules/communityTranslations/routes/UserPanelGetTranslations.ts
+++ b/src/modules/communityTranslations/routes/UserPanelGetTranslations.ts
@@ -1,0 +1,26 @@
+import { Route, RouteMethod, ServiceContainer } from "zumito-framework";
+import { UserPanelAuthService } from "@zumito-team/user-panel-module/services/UserPanelAuthService";
+import { CommunityTranslationService } from "../services/CommunityTranslationService";
+
+export class UserPanelGetTranslations extends Route {
+    method = RouteMethod.get;
+    path = '/panel/:lang/translations';
+
+    constructor(
+        private auth: UserPanelAuthService = ServiceContainer.getService(UserPanelAuthService),
+        private communityService: CommunityTranslationService = ServiceContainer.getService(CommunityTranslationService),
+    ) {
+        super();
+    }
+
+    async execute(req: any, res: any) {
+        const authData = await this.auth.isLoginValid(req);
+        if (!authData.isValid) {
+            return res.redirect('/panel/login');
+        }
+        const lang = req.params.lang;
+        req.lang = lang;
+        const missing = await this.communityService.getMissingTranslations(lang);
+        res.json(missing);
+    }
+}

--- a/src/modules/communityTranslations/routes/UserPanelSubmitTranslation.ts
+++ b/src/modules/communityTranslations/routes/UserPanelSubmitTranslation.ts
@@ -1,0 +1,37 @@
+import { Route, RouteMethod, ServiceContainer, TranslationManager } from "zumito-framework";
+import { UserPanelAuthService } from "@zumito-team/user-panel-module/services/UserPanelAuthService";
+import { CommunityTranslationService } from "../services/CommunityTranslationService";
+
+export class UserPanelSubmitTranslation extends Route {
+    method = RouteMethod.post;
+    path = '/panel/:lang/translations';
+
+    constructor(
+        private auth: UserPanelAuthService = ServiceContainer.getService(UserPanelAuthService),
+        private communityService: CommunityTranslationService = ServiceContainer.getService(CommunityTranslationService),
+        private translator: TranslationManager = ServiceContainer.getService(TranslationManager),
+    ) {
+        super();
+    }
+
+    async execute(req: any, res: any) {
+        const authData = await this.auth.isLoginValid(req);
+        if (!authData.isValid) {
+            return res.redirect('/panel/login');
+        }
+        const lang = req.params.lang;
+        req.lang = lang;
+        const { filePath, key, translation } = req.body;
+        try {
+            await this.communityService.submitTranslation({
+                lang,
+                filePath,
+                key,
+                value: translation,
+            });
+            res.json({ message: this.translator.get('community.submitted', lang) });
+        } catch {
+            res.status(500).json({ message: this.translator.get('community.error', lang) });
+        }
+    }
+}

--- a/src/modules/communityTranslations/routes/UserPanelVoteTranslation.ts
+++ b/src/modules/communityTranslations/routes/UserPanelVoteTranslation.ts
@@ -1,0 +1,34 @@
+import { Route, RouteMethod, ServiceContainer, TranslationManager } from "zumito-framework";
+import { UserPanelAuthService } from "@zumito-team/user-panel-module/services/UserPanelAuthService";
+import { CommunityTranslationService } from "../services/CommunityTranslationService";
+
+export class UserPanelVoteTranslation extends Route {
+    method = RouteMethod.post;
+    path = '/panel/translations/vote/:id';
+
+    constructor(
+        private auth: UserPanelAuthService = ServiceContainer.getService(UserPanelAuthService),
+        private communityService: CommunityTranslationService = ServiceContainer.getService(CommunityTranslationService),
+        private translator: TranslationManager = ServiceContainer.getService(TranslationManager),
+    ) {
+        super();
+    }
+
+    async execute(req: any, res: any) {
+        const authData = await this.auth.isLoginValid(req);
+        if (!authData.isValid) {
+            return res.redirect('/panel/login');
+        }
+        const lang = req.body.lang || 'en';
+        req.lang = lang;
+        const id = req.params.id;
+        const vote = Number(req.body.vote) > 0 ? 1 : -1;
+        try {
+            await this.communityService.voteTranslation(id, vote);
+            res.json({ message: this.translator.get('community.voteRegistered', lang) });
+        } catch {
+            res.status(500).json({ message: this.translator.get('community.error', lang) });
+        }
+    }
+}
+

--- a/src/modules/communityTranslations/services/CommunityTranslationService.ts
+++ b/src/modules/communityTranslations/services/CommunityTranslationService.ts
@@ -1,0 +1,153 @@
+import { ServiceContainer, ZumitoFramework } from "zumito-framework";
+import { promises as fs } from "fs";
+import path from "path";
+import recursive from "fs-readdir-recursive";
+import { ObjectId } from "mongodb";
+import os from "os";
+import { spawnSync } from "child_process";
+
+interface MissingTranslation {
+    key: string;
+    defaultValue: string;
+    filePath: string;
+}
+
+interface TranslationProposal {
+    lang: string;
+    filePath: string;
+    key: string;
+    value: string;
+}
+
+interface CommunityTranslation {
+    id: string;
+    lang: string;
+    filePath: string;
+    key: string;
+    value: string;
+    votes: number;
+}
+
+export class CommunityTranslationService {
+    constructor(
+        private framework: ZumitoFramework = ServiceContainer.getService(ZumitoFramework),
+    ) {}
+
+    async getMissingTranslations(lang: string): Promise<MissingTranslation[]> {
+        const modulesPath = path.resolve(process.cwd(), "src/modules");
+        const files = recursive(modulesPath);
+        const missing: MissingTranslation[] = [];
+
+        for (const file of files) {
+            if (!file.endsWith("/en.json")) continue;
+            const enPath = path.join(modulesPath, file);
+            const targetPath = enPath.replace(/en\.json$/, `${lang}.json`);
+            const enData = JSON.parse(await fs.readFile(enPath, "utf8"));
+            let langData: any = {};
+            try {
+                const content = await fs.readFile(targetPath, "utf8");
+                langData = JSON.parse(content);
+            } catch {
+                langData = {};
+            }
+            const enFlat = this.flatten(enData);
+            const langFlat = this.flatten(langData);
+            for (const key of Object.keys(enFlat)) {
+                if (!(key in langFlat)) {
+                    missing.push({
+                        key,
+                        defaultValue: enFlat[key],
+                        filePath: path.relative(process.cwd(), targetPath),
+                    });
+                }
+            }
+        }
+
+        return missing;
+    }
+
+    private flatten(obj: any, prefix = ""): Record<string, string> {
+        const result: Record<string, string> = {};
+        for (const [key, value] of Object.entries(obj)) {
+            const newKey = prefix ? `${prefix}.${key}` : key;
+            if (value && typeof value === "object") {
+                Object.assign(result, this.flatten(value as any, newKey));
+            } else {
+                result[newKey] = String(value);
+            }
+        }
+        return result;
+    }
+
+    async submitTranslation(data: TranslationProposal): Promise<void> {
+        await this.framework.database.collection("community_translations").insertOne({
+            ...data,
+            votes: 0,
+            createdAt: new Date(),
+        });
+    }
+
+    async getCommunityTranslations(lang: string): Promise<CommunityTranslation[]> {
+        const results = await this.framework.database.collection("community_translations").find({ lang }).toArray();
+        return results.map(r => ({
+            id: r._id.toString(),
+            lang: r.lang,
+            filePath: r.filePath,
+            key: r.key,
+            value: r.value,
+            votes: r.votes || 0,
+        }));
+    }
+
+    async voteTranslation(id: string, delta: number): Promise<void> {
+        await this.framework.database.collection("community_translations").updateOne({
+            _id: new ObjectId(id),
+        }, { $inc: { votes: delta } });
+    }
+
+    async generatePatch(): Promise<string> {
+        const approved = await this.framework.database.collection("community_translations").find({ votes: { $gte: 3 } }).toArray();
+        if (approved.length === 0) return "";
+        const grouped: Record<string, any[]> = {};
+        for (const item of approved) {
+            if (!grouped[item.filePath]) grouped[item.filePath] = [];
+            grouped[item.filePath].push(item);
+        }
+        let patch = "";
+        for (const [filePath, items] of Object.entries(grouped)) {
+            const absPath = path.resolve(process.cwd(), filePath);
+            let original = "{}\n";
+            try {
+                original = await fs.readFile(absPath, "utf8");
+            } catch {}
+            let json: any = {};
+            try {
+                json = JSON.parse(original);
+            } catch {
+                json = {};
+            }
+            for (const item of items) {
+                const parts = item.key.split(".");
+                let obj = json;
+                for (let i = 0; i < parts.length - 1; i++) {
+                    const part = parts[i];
+                    obj[part] = obj[part] || {};
+                    obj = obj[part];
+                }
+                obj[parts[parts.length - 1]] = item.value;
+            }
+            const updated = JSON.stringify(json, null, 4) + "\n";
+            const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "ct-"));
+            const oldFile = path.join(tmpDir, "old.json");
+            const newFile = path.join(tmpDir, "new.json");
+            await fs.writeFile(oldFile, original);
+            await fs.writeFile(newFile, updated);
+            const diff = spawnSync("diff", ["-u", oldFile, newFile], { encoding: "utf8" }).stdout;
+            patch += `diff --git a/${filePath} b/${filePath}\n${diff}`;
+            await fs.rm(tmpDir, { recursive: true, force: true });
+        }
+        return patch;
+    }
+}
+
+export type { MissingTranslation, TranslationProposal, CommunityTranslation };

--- a/src/modules/communityTranslations/translations/community/en.json
+++ b/src/modules/communityTranslations/translations/community/en.json
@@ -1,0 +1,6 @@
+{
+    "submitted": "Translation submitted.",
+    "voteRegistered": "Vote recorded.",
+    "noTranslations": "No translations available.",
+    "error": "Unexpected error."
+}

--- a/src/modules/communityTranslations/translations/community/es.json
+++ b/src/modules/communityTranslations/translations/community/es.json
@@ -1,0 +1,6 @@
+{
+    "submitted": "Traducción enviada.",
+    "voteRegistered": "Voto registrado.",
+    "noTranslations": "No hay traducciones disponibles.",
+    "error": "Error inesperado."
+}


### PR DESCRIPTION
## Summary
- extend community translation service with proposal listing, voting, and patch generation
- expose routes for retrieving proposals, voting, and fetching admin patch
- add i18n strings for voting and admin messages

## Testing
- `npx eslint .` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*
- `npm install` *(fails: ENETUNREACH when downloading dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68b6252dd30c832fab7f02d4d6931296