### PR TITLE
feat(tasks): activity log, review-request DMs, and UI toasts

### DIFF
--- a/src/modules/tasks/routes/AdminTasksApiAssignOwner.ts
+++ b/src/modules/tasks/routes/AdminTasksApiAssignOwner.ts
@@ -1,4 +1,4 @@
-import { Route, RouteMethod, ServiceContainer } from "zumito-framework";
+import { Route, RouteMethod, ServiceContainer, TranslationManager } from "zumito-framework";
 import { AdminAuthService } from "@zumito-team/admin-module/services/AdminAuthService";
 import { TaskService } from "../services/TaskService";
 import { ActionRowBuilder, ButtonBuilder, ButtonStyle, Client } from "discord.js";
@@ -19,6 +19,16 @@ export class AdminTasksApiAssignOwner extends Route {
         if (!id) return res.status(400).json({ ok: false, error: 'Missing id' });
         let name = ownerName ? String(ownerName) : '';
         let avatar: string | null = null;
+        // Resolve actor (admin performing the action)
+        let actorId: string = 'admin';
+        let actorName: string = 'Admin';
+        try {
+            const auth: any = await (this.adminAuthService as any).isLoginValid(req).catch(() => null);
+            actorId = (auth && (auth.user?.id || auth.data?.discordUserData?.id || auth.data?.user?.id || auth.data?.discordUserId))
+                || req.user?.id || req.user?.discord?.id || 'admin';
+            actorName = (auth && (auth.user?.name || auth.data?.discordUserData?.globalName || auth.data?.discordUserData?.username))
+                || req.user?.name || 'Admin';
+        } catch {}
         if (ownerId) {
             try {
                 const user = await this.client.users.fetch(String(ownerId)).catch(() => null);
@@ -30,11 +40,26 @@ export class AdminTasksApiAssignOwner extends Route {
                     const row: any = new ActionRowBuilder<ButtonBuilder>().addComponents(
                         new ButtonBuilder().setStyle(ButtonStyle.Link).setURL(link).setLabel('Open Task')
                     );
-                    await user.send({ content: `You have been assigned as owner/manager of a task.`, components: [row] });
+                    const tmpl = (ServiceContainer.getService(TranslationManager) as any).get?.('tasks.dm.assignedOwner')
+                        || 'You have been assigned as owner/manager of a task.';
+                    await user.send({ content: tmpl, components: [row] });
                 }
             } catch {}
         }
         const task = await this.taskService.setOwner(String(id), ownerId ? { id: String(ownerId), name: name || String(ownerId), avatar } : null);
+        try {
+            // Resolve actor avatar for nicer log
+            let actorAvatar: string | null = null;
+            if (actorId) {
+                const actor = await this.client.users.fetch(String(actorId)).catch(() => null as any);
+                actorAvatar = actor && typeof actor.displayAvatarURL === 'function' ? actor.displayAvatarURL({ forceStatic: true, size: 64 }) : null;
+            }
+            await this.taskService.addActivity(String(id), {
+                type: 'ownerAssigned',
+                user: { id: actorId, name: actorName, avatar: actorAvatar },
+                details: { owner: ownerId ? { id: String(ownerId), name: name || String(ownerId) } : null }
+            });
+        } catch {}
         res.json({ ok: true, task });
     }
 }

--- a/src/modules/tasks/routes/AdminTasksApiTesterAdd.ts
+++ b/src/modules/tasks/routes/AdminTasksApiTesterAdd.ts
@@ -21,21 +21,74 @@ export class AdminTasksApiTesterAdd extends Route {
         const taskId = String(id);
         let name = String(testerName || '');
         let avatar: string | null = null;
-        // Try to resolve user info and DM
+        // Resolve actor (admin performing the action)
+        let actorId: string = 'admin';
+        let actorName: string = 'Admin';
+        try {
+            const auth: any = await (this.adminAuthService as any).isLoginValid(req).catch(() => null);
+            actorId = (auth && (auth.user?.id || auth.data?.discordUserData?.id || auth.data?.user?.id || auth.data?.discordUserId))
+                || req.user?.id || req.user?.discord?.id || 'admin';
+            actorName = (auth && (auth.user?.name || auth.data?.discordUserData?.globalName || auth.data?.discordUserData?.username))
+                || req.user?.name || 'Admin';
+        } catch {}
+        // Try to enrich actor name from Discord profile
+        try {
+            if (actorId && actorName === 'Admin') {
+                const actor = await this.client.users.fetch(String(actorId)).catch(() => null as any);
+                if (actor) {
+                    actorName = actor.globalName || actor.username || actorName;
+                }
+            }
+        } catch {}
+        // Prepare DM info (we will send after we know task title)
+        let dmUser: any = null;
+        let dmRow: any = null;
         try {
             const user = await this.client.users.fetch(String(testerId)).catch(() => null);
             if (user) {
+                dmUser = user;
                 name = name || (user.globalName || user.username);
                 avatar = typeof user.displayAvatarURL === 'function' ? user.displayAvatarURL({ forceStatic: true, size: 128 }) : null;
                 const base = (req.protocol && req.get) ? `${req.protocol}://${req.get('host')}` : '';
                 const link = `${base}/admin/tasks/kanban?t=${encodeURIComponent(taskId)}`;
-                const row: any = new ActionRowBuilder<ButtonBuilder>().addComponents(
+                dmRow = new ActionRowBuilder<ButtonBuilder>().addComponents(
                     new ButtonBuilder().setStyle(ButtonStyle.Link).setURL(link).setLabel(this.translationService.get('tasks.action.openTask') || 'Open Task')
                 );
-                await user.send({ content: `You have been added as a tester.`, components: [row] });
             }
         } catch {}
-        const updated = await this.taskService.update(taskId, { testers: [{ id: String(testerId), name: name || String(testerId), avatar, approved: false }] });
+        // Merge tester into existing list instead of overwriting
+        let updated = await (this.taskService as any)["col"]().findOne({ id: taskId }).catch(() => null as any);
+        const testers = Array.isArray(updated?.testers) ? updated.testers : [];
+        const idx = testers.findIndex((t: any) => String(t.id) === String(testerId));
+        const entry = { id: String(testerId), name: name || String(testerId), avatar, approved: false } as any;
+        if (idx >= 0) testers[idx] = { ...testers[idx], ...entry };
+        else testers.push(entry);
+        updated = await this.taskService.update(taskId, { testers } as any);
+        // Send DM with actor and task title
+        try {
+            const taskTitle = (updated && updated.title) || (typeof id === 'string' ? id : String(id));
+            if (dmUser && dmRow) {
+                const tmpl = this.translationService.get('tasks.dm.assignedTester')
+                    || 'You have been added as a tester by {actor} for task: {task}';
+                const content = String(tmpl)
+                    .replace('{actor}', actorName)
+                    .replace('{task}', taskTitle);
+                await dmUser.send({ content, components: [dmRow] });
+            }
+        } catch {}
+        try {
+            // Resolve actor avatar for nicer log
+            let actorAvatar: string | null = null;
+            if (actorId) {
+                const actor = await this.client.users.fetch(String(actorId)).catch(() => null as any);
+                actorAvatar = actor && typeof actor.displayAvatarURL === 'function' ? actor.displayAvatarURL({ forceStatic: true, size: 64 }) : null;
+            }
+            await this.taskService.addActivity(taskId, {
+                type: 'testerAdded',
+                user: { id: actorId, name: actorName, avatar: actorAvatar },
+                details: { tester: { id: String(testerId), name: name || String(testerId) } }
+            });
+        } catch {}
         res.json({ ok: true, task: updated });
     }
 }

--- a/src/modules/tasks/translations/en.json
+++ b/src/modules/tasks/translations/en.json
@@ -28,6 +28,7 @@
             "testers": "Testers",
             "owner": "Owner",
             "comments": "Comments",
+            "activity": "Activity",
             "public": "Public",
             "publicUrl": "Public URL"
         },
@@ -62,10 +63,27 @@
             "none": "No pending reviews"
         },
         "dm": {
-            "requestReview": "{requester} asked you to review the task: {task}"
+            "requestReview": "{requester} asked you to review the task: {task}",
+            "assignedOwner": "You have been assigned as owner/manager of a task.",
+            "assignedTester": "You have been added as a tester by {actor} for task: {task}"
         },
         "confirm": {
             "moveToTesting": "The task is not in Testing. Move it to Testing before requesting review?"
+        },
+        "activity": {
+            "title": "Activity",
+            "none": "No activity yet",
+            "statusChanged": "{actor} changed status: {from} → {to}",
+            "reviewRequested": "{actor} requested review ({sent}/{total})",
+            "reviewApproved": "{actor} approved the task",
+            "reviewDenied": "{actor} denied the task",
+            "ownerAssigned": "{actor} assigned owner: {owner}",
+            "testerAdded": "{actor} added tester: {tester}"
+        },
+        "toast": {
+            "reviewRequested": "Review requested: {sent}/{total} DMs sent",
+            "success": "Action completed successfully",
+            "error": "Something went wrong"
         }
     }
 }

--- a/src/modules/tasks/translations/es.json
+++ b/src/modules/tasks/translations/es.json
@@ -28,6 +28,7 @@
             "testers": "Testers",
             "owner": "Responsable",
             "comments": "Comentarios",
+            "activity": "Actividad",
             "public": "Pública",
             "publicUrl": "URL pública"
         },
@@ -62,10 +63,27 @@
             "none": "Sin revisiones pendientes"
         },
         "dm": {
-            "requestReview": "El usuario {requester} te ha solicitado que revises la tarea: {task}"
+            "requestReview": "El usuario {requester} te ha solicitado que revises la tarea: {task}",
+            "assignedOwner": "Has sido asignado/a como responsable de una tarea.",
+            "assignedTester": "Has sido añadido/a como tester por {actor} en la tarea: {task}"
         },
         "confirm": {
             "moveToTesting": "La tarea no está en Pruebas. ¿Quieres moverla a Pruebas antes de solicitar revisión?"
+        },
+        "activity": {
+            "title": "Actividad",
+            "none": "Sin actividad",
+            "statusChanged": "{actor} cambió el estado: {from} → {to}",
+            "reviewRequested": "{actor} solicitó revisión ({sent}/{total})",
+            "reviewApproved": "{actor} aprobó la tarea",
+            "reviewDenied": "{actor} rechazó la tarea",
+            "ownerAssigned": "{actor} asignó responsable: {owner}",
+            "testerAdded": "{actor} añadió tester: {tester}"
+        },
+        "toast": {
+            "reviewRequested": "Revisión solicitada: {sent}/{total} MD enviados",
+            "success": "Acción completada con éxito",
+            "error": "Ha ocurrido un error"
         }
     }
 }

--- a/src/modules/tasks/views/admin_kanban.ejs
+++ b/src/modules/tasks/views/admin_kanban.ejs
@@ -1,4 +1,12 @@
 <div class="card mt-6" x-data="kanban()">
+  <!-- Toasts -->
+  <div class="fixed top-4 right-4 space-y-2" aria-live="polite" style="z-index: 9999;">
+    <template x-for="t in toasts" :key="t.id">
+      <div class="px-4 py-2 rounded shadow text-sm"
+           :class="t.type==='error' ? 'bg-red-600 text-white' : 'bg-discord-dark-300 text-white'"
+           x-text="t.message"></div>
+    </template>
+  </div>
   <div class="flex items-center justify-between mb-4">
     <div class="text-lg font-semibold"><%= t.get('tasks.admin.title') %></div>
     <button class="btn-primary" @click="openCreateModal = true">
@@ -233,11 +241,26 @@
                   <img x-show="detail.selectedTesterAvatar" :src="detail.selectedTesterAvatar" class="w-5 h-5 rounded-full object-cover"/>
                   <span class="text-sm text-white" x-text="detail.testerQuery"></span>
                 </div>
-                <button type="button" class="px-3 py-2 rounded bg-discord-dark-400 hover:bg-discord-dark-500" @click="addTester()"><%= t.get('tasks.action.add') %></button>
-                <button type="button" class="px-3 py-2 rounded bg-discord-dark-400 hover:bg-discord-dark-500" @click="requestReview()"><%= t.get('tasks.action.requestReview') %></button>
+                <button type="button" class="px-3 py-2 rounded bg-discord-dark-400 hover:bg-discord-dark-500" @click.stop="addTester()"><%= t.get('tasks.action.add') %></button>
+                <button type="button" class="px-3 py-2 rounded bg-discord-dark-400 hover:bg-discord-dark-500" @click.stop="requestReview()"><%= t.get('tasks.action.requestReview') %></button>
               </div>
             </div>
           </div>
+        </div>
+      </div>
+      <div class="mt-4">
+        <label class="block mb-1 text-sm font-medium"><%= t.get('tasks.field.activity') %></label>
+        <div class="space-y-2 max-h-40 overflow-y-auto bg-discord-dark-300 rounded p-2">
+          <template x-for="a in (current.actions||[]).slice().sort((x,y)=> (y.at||0)-(x.at||0))" :key="a.id">
+            <div class="text-sm flex items-start gap-2">
+              <img x-show="a.user && a.user.avatar" :src="a.user.avatar" alt="avatar" class="w-5 h-5 rounded-full object-cover mt-0.5"/>
+              <div>
+                <div class="text-discord-light-300" x-text="formatAction(a)"></div>
+                <div class="text-[10px] text-discord-light-300" x-text="formatDate(a.at)"></div>
+              </div>
+            </div>
+          </template>
+          <div class="text-xs text-discord-light-300" x-show="!(current.actions||[]).length"><%= t.get('tasks.activity.none') %></div>
         </div>
       </div>
       <div class="mt-4">
@@ -271,6 +294,7 @@
       openCreateModal: false,
       openDetailModal: false,
       drag: null,
+      toasts: [],
       columns: [
         { id: 'backlog', name: '<%= t.get('tasks.column.backlog') %>' },
         { id: 'working', name: '<%= t.get('tasks.column.working') %>' },
@@ -424,7 +448,28 @@
               if (updated) this.current = updated;
             }
           }
-          await fetch('/admin/tasks/api/request-review', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ id: this.current.id }) });
+          const res = await fetch('/admin/tasks/api/request-review', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ id: this.current.id }) });
+          const data = await res.json().catch(() => ({ ok: false }));
+          if (data && data.ok) {
+            const msg = (data.sent != null && data.count != null)
+              ? `<%= t.get('tasks.toast.reviewRequested') %>`.replace('{sent}', String(data.sent)).replace('{total}', String(data.count))
+              : '<%= t.get('tasks.toast.success') %>';
+            this.showToast(msg, 'success');
+            // Optimistic activity log update for instant feedback
+            try {
+              const viewer = (window.__viewer || {});
+              if (!this.current.actions) this.current.actions = [];
+              this.current.actions.unshift({
+                id: Math.random().toString(36).slice(2),
+                type: 'reviewRequested',
+                user: { id: viewer.id || 'admin', name: viewer.name || 'Admin', avatar: viewer.avatar || null },
+                details: { total: Number(data.count||0), sent: Number(data.sent||0), failed: Number(data.failed||0) },
+                at: Date.now()
+              });
+            } catch {}
+          } else {
+            this.showToast('<%= t.get('tasks.toast.error') %>', 'error');
+          }
         } catch {}
       },
 
@@ -481,6 +526,44 @@
       },
 
       async init() { await this.load(); await this.loadProjects(); const sp = new URLSearchParams(window.location.search); const tid = sp.get('t'); if (tid) this.openById(tid); },
+      showToast(message, type) {
+        const id = Math.random().toString(36).slice(2);
+        this.toasts.push({ id, message, type: type||'success' });
+        setTimeout(() => { this.toasts = this.toasts.filter(x => x.id !== id); }, 3000);
+      },
+      formatDate(ts) {
+        try { return new Date(ts).toLocaleString(); } catch { return ''; }
+      },
+      formatAction(a) {
+        const map = {
+          statusChanged: '<%= t.get('tasks.activity.statusChanged') %>',
+          reviewRequested: '<%= t.get('tasks.activity.reviewRequested') %>',
+          reviewApproved: '<%= t.get('tasks.activity.reviewApproved') %>',
+          reviewDenied: '<%= t.get('tasks.activity.reviewDenied') %>',
+          ownerAssigned: '<%= t.get('tasks.activity.ownerAssigned') %>',
+          testerAdded: '<%= t.get('tasks.activity.testerAdded') %>'
+        };
+        const statusLabels = {
+          backlog: '<%= t.get('tasks.column.backlog') %>',
+          working: '<%= t.get('tasks.column.working') %>',
+          testing: '<%= t.get('tasks.column.testing') %>',
+          pendingFix: '<%= t.get('tasks.column.pendingFix') %>',
+          pendingPublish: '<%= t.get('tasks.column.pendingPublish') %>',
+          beta: '<%= t.get('tasks.column.beta') %>',
+          done: '<%= t.get('tasks.column.done') %>'
+        };
+        const tpl = map[a.type] || a.type;
+        const actor = (a.user && (a.user.name || a.user.id)) || '';
+        const details = a.details || {};
+        return String(tpl)
+          .replace('{actor}', actor)
+          .replace('{owner}', details.owner?.name || details.owner?.id || '')
+          .replace('{from}', statusLabels[details.from] || details.from || '')
+          .replace('{to}', statusLabels[details.to] || details.to || '')
+          .replace('{tester}', details.tester?.name || details.tester?.id || '')
+          .replace('{sent}', String(details.sent || '0'))
+          .replace('{total}', String(details.total || '0'));
+      },
       async loadProjects() {
         const res = await fetch('/admin/tasks/api/github/projects?org=ZumitoTeam');
         const data = await res.json();


### PR DESCRIPTION
**Summary**
- Add task activity log covering: tester added, review requested (with counts), approve/deny actions, owner assigned, and status changes.
- Improve reviewer DMs: merge testers on add, avoid overwriting existing testers; fallback to DM all testers when none pending.
- Resolve actor/tester display names and avatars from Discord for clearer audit trail.
- Enhance Kanban modal: new Activity section, higher z-index toasts, and optimistic updates.
- Pending Reviews flow: log approvals after new review requests and update status accordingly.
- i18n: Provide English/Spanish strings for activity items, toasts, and DMs.

**Testing**
- Linting: ran `npx eslint .` locally.
  - Result: 1020 problems (680 errors, 340 warnings). Many are pre-existing across unrelated modules; this PR focuses on the Tasks module features and does not aim to resolve repo-wide lint issues.
  - A subset of 311 errors and 8 warnings are auto-fixable via `--fix`, but I did not apply mass fixes to avoid scope creep.
- No license files were modified.

If you want, I can follow up with a separate PR to address lint issues within the Tasks module specifically.
